### PR TITLE
Cakephp plugin template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+vendor/
+composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+#This Travis config template file was taken from https://github.com/FriendsOfCake/travis
+language: php
+
+php:
+  - 5.6
+  - 7.0
+
+sudo: false
+
+env:
+  matrix:
+    - DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
+    - DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
+    - DB=sqlite db_dsn='sqlite:///:memory:'
+  global:
+    - DEFAULT=1
+
+matrix:
+  fast_finish: true
+
+install:
+  - composer install 
+  - mkdir -p build/logs
+
+before_script:
+  - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi"
+  - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi"
+
+script:
+  - vendor/bin/phpunit
+  - vendor/bin/phpcs --config-set ignore_warnings_on_exit 1
+  - vendor/bin/phpcs -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests
+
+after_success:
+  - curl -s https://codecov.io/bash > /tmp/codecov.sh
+  - chmod +x /tmp/codecov.sh
+  - /tmp/codecov.sh -s build/logs
+
+notifications:
+  email:
+    - webdev@qobocloud.com

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "cakedc/users": "~3.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "*"
+        "phpunit/phpunit": "*",
+        "cakephp/cakephp-codesniffer": "dev-master"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,19 +4,34 @@
     processIsolation="false"
     stopOnFailure="false"
     syntaxCheck="false"
-    bootstrap="./tests/bootstrap.php"
+    bootstrap="./vendor/cakephp/cakephp/tests/bootstrap.php"
+    verbose="true"
     >
     <php>
         <ini name="memory_limit" value="-1"/>
         <ini name="apc.enable_cli" value="1"/>
     </php>
 
-    <!-- Add any additional test suites you want to run here -->
-    <testsuites>
-        <testsuite name="Cakephp-messaging-center Test Suite">
-            <directory>./tests/TestCase</directory>
-        </testsuite>
-    </testsuites>
+	<filter>
+		<whitelist>
+			<directory suffix=".php">.</directory>
+			<exclude>
+				<directory>./build/</directory>
+				<directory>./config/</directory>
+				<directory>./doc/</directory>
+				<directory>./tests/</directory>
+				<directory>./vendor/</directory>
+			</exclude>
+		</whitelist>
+	</filter>
+
+	<logging>
+        <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
+		<log type="coverage-html" target="build/coverage"/>
+		<log type="coverage-clover" target="build/logs/clover.xml"/>
+		<log type="coverage-crap4j" target="build/logs/crap4j.xml"/>
+		<log type="junit" target="build/logs/junit.xml" logIncompleteSkipped="false"/>
+	</logging>
 
     <!-- Setup a listener for fixtures -->
     <listeners>
@@ -29,15 +44,11 @@
         </listener>
     </listeners>
 
-    <!-- Prevent coverage reports from looking in tests and vendors -->
-    <filter>
-        <blacklist>
-            <directory suffix=".php">./vendor/</directory>
-            <directory suffix=".ctp">./vendor/</directory>
-
-            <directory suffix=".php">./tests/</directory>
-            <directory suffix=".ctp">./tests/</directory>
-        </blacklist>
-    </filter>
+    <!-- Add any additional test suites you want to run here -->
+    <testsuites>
+        <testsuite name="MessagingCenter Test Suite">
+            <directory>./tests/TestCase</directory>
+        </testsuite>
+    </testsuites>
 
 </phpunit>


### PR DESCRIPTION
* Merged in [cakephp-plugin-template](https://github.com/QoboLtd/cakephp-plugin-template/releases/tag/v1.0.0)
* Added CodeSniffer to development requirements

Currently the unit tests are failing, because of the `from` field in the fixture, which is probably unescaped.  @georgeconstantinou will fix the unit tests in a separate PR.  The purpose of this PR is to integrate unit tests and code coverage.  Merging.