### PR TITLE
fixing the bug for properly setting variables

### DIFF
--- a/src/View/Cell/InboxCell.php
+++ b/src/View/Cell/InboxCell.php
@@ -35,9 +35,9 @@ class InboxCell extends Cell
             ]
         ]);
 
-        $this->set('unread_format', $format);
-        $this->set('unread_count', (int)$unread->count());
-        $this->set('max_unread_count', static::MAX_UNREAD_COUNT);
+        $this->set('unreadFormat', $format);
+        $this->set('unreadCount', (int)$unread->count());
+        $this->set('maxUnreadCount', static::MAX_UNREAD_COUNT);
     }
 
     /**


### PR DESCRIPTION
The prettifier for passing coding strandards ignored the actual setting of the variables in the Cell