### PR TITLE
Event names enumeration (task #4352)

### DIFF
--- a/src/Event/EventName.php
+++ b/src/Event/EventName.php
@@ -1,0 +1,12 @@
+<?php
+namespace MessagingCenter\Event;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * Event Name enum
+ */
+class EventName extends Enum
+{
+    const NOTIFY_BEFORE_RENDER = 'MessagingCenter.Notify.beforeRender';
+}

--- a/src/Event/Model/UserListener.php
+++ b/src/Event/Model/UserListener.php
@@ -9,6 +9,7 @@ use Cake\Event\Event;
 use Cake\Event\EventDispatcherTrait;
 use Cake\Event\EventListenerInterface;
 use Cake\ORM\TableRegistry;
+use MessagingCenter\Event\EventName;
 use MessagingCenter\Notifier\MessageNotifier;
 
 class UserListener implements EventListenerInterface
@@ -71,7 +72,7 @@ class UserListener implements EventListenerInterface
         $this->Notifier->template('MessagingCenter.welcome');
 
         // broadcast event for modifying message data before passing them to the Notifier
-        $event = new Event('MessagingCenter.Notify.beforeRender', $this, [
+        $event = new Event((string)EventName::NOTIFY_BEFORE_RENDER(), $this, [
             'table' => TableRegistry::get('Messages'),
             'entity' => $entity,
             'data' => $data

--- a/src/Model/Behavior/NotifyBehavior.php
+++ b/src/Model/Behavior/NotifyBehavior.php
@@ -10,6 +10,7 @@ use Cake\ORM\Behavior;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
+use MessagingCenter\Event\EventName;
 use MessagingCenter\Notifier\MessageNotifier;
 
 class NotifyBehavior extends Behavior
@@ -225,7 +226,7 @@ class NotifyBehavior extends Behavior
         }
 
         // broadcast event for modifying message data before passing them to the Notifier
-        $event = new Event('MessagingCenter.Notify.beforeRender', $this, [
+        $event = new Event((string)EventName::NOTIFY_BEFORE_RENDER(), $this, [
             'table' => $this->getTable(),
             'entity' => $entity,
             'data' => $data


### PR DESCRIPTION
Use [php-enum](https://github.com/myclabs/php-enum) library to define event names enum. Modified all events to use `EventName` enumeration class.