### PR TITLE
Removed require-dev from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,6 @@
     "require": {
         "qobo/cakephp-utils": "^6.0"
     },
-    "require-dev": {
-        "phpunit/phpunit": "^5.0",
-        "cakephp/cakephp-codesniffer": "^3.0"
-    },
     "autoload": {
         "psr-4": {
             "MessagingCenter\\": "src",


### PR DESCRIPTION
Development requirements are already provided by the required
CakePHP Utils plugin.