### PR TITLE
Table renaming (task #5648)

### DIFF
--- a/config/Migrations/20180327085709_RenameMessages.php
+++ b/config/Migrations/20180327085709_RenameMessages.php
@@ -1,0 +1,18 @@
+<?php
+use Migrations\AbstractMigration;
+
+class RenameMessages extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $this->table('messages')
+            ->rename('qobo_messages');
+    }
+}

--- a/src/Model/Table/MessagesTable.php
+++ b/src/Model/Table/MessagesTable.php
@@ -46,7 +46,7 @@ class MessagesTable extends Table
     {
         parent::initialize($config);
 
-        $this->table('messages');
+        $this->table('qobo_messages');
         $this->displayField('id');
         $this->primaryKey('id');
 

--- a/tests/Fixture/MessagesFixture.php
+++ b/tests/Fixture/MessagesFixture.php
@@ -9,6 +9,7 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class MessagesFixture extends TestFixture
 {
+    public $table = 'qobo_messages';
 
     /**
      * Fields


### PR DESCRIPTION
Renamed table from `messages` to `qobo_messages` to avoid conflicts with application tables.