### PR TITLE
CakePHP 3.6 support and PHPStan (task #8244)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,6 @@ end_of_line = crlf
 [*.yml]
 indent_style = space
 indent_size = 2
+
+[*.twig]
+insert_final_newline = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,52 @@
+# Define the line ending behavior of the different file extensions
+# Set default behaviour, in case users don't have core.autocrlf set.
+* text=auto
+* text eol=lf
+
+# Explicitly declare text files we want to always be normalized and converted
+# to native line endings on checkout.
+.htaccess text
+*.css text diff=css
+*.ctp text diff=php
+*.default text
+*.html text diff=html
+*.ini text
+*.js text
+*.md text
+*.php text diff=php
+*.po text
+*.properties text
+*.sql text
+*.svg text
+*.txt text
+*.xml text
+*.yml text
+
+# Declare files that will always have CRLF line endings on checkout.
+*.bat eol=crlf
+
+# Declare files that will always have LF line endings on checkout.
+*.pem eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+composer binary
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary
+*.mo binary
+*.pdf binary
+*.phar binary
+
+# Web fonts are binary
+*.otf binary
+*.eot binary
+*.ttf binary
+*.woff binary
+*.woff2 binary
+
+# Treat zip files as binary
+*.7z binary
+*.bz2 binary
+*.gz binary
+*.zip binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,41 @@
+# Project specific files #
+##########################
 build/
 vendor/
+cghooks.lock
+
 composer.lock
 config/Migrations/schema-dump-default.lock
 config/Migrations/schema-dump-test.lock
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Icon?
+ehthumbs.db
+Thumbs.db
+
+# Tool specific files #
+#######################
+# vim
+*~
+*.swp
+*.swo
+# sublime text & textmate
+*.sublime-*
+*.stTheme.cache
+*.tmlanguage.cache
+*.tmPreferences.cache
+# Eclipse
+.settings/*
+# JetBrains, aka PHPStorm, IntelliJ IDEA
+.idea/*
+# NetBeans
+nbproject/*
+# Visual Studio Code
+.vscode
+# Sass preprocessor
+.sass-cache/

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,6 +1,7 @@
 linters:
   phpcs:
     standard: CakePHP
-    extensions: '.php,.ctp'
+    extensions: 'php,ctp'
+    exclude: 'Generic.Commenting.Todo'
 files:
-  ignore: ['config/*', 'tests/*']
+    ignore: ['webroot/plugins/*']

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,8 @@
-#This Travis config template file was taken from https://github.com/FriendsOfCake/travis
-sudo: true
-dist: trusty
-
 language: php
 
-php:
-  - 7.1
-  - 7.2
-  - nightly
+dist: trusty
+
+sudo: false
 
 cache:
   directories:
@@ -21,25 +16,39 @@ env:
 
 matrix:
   fast_finish: true
+
   allow_failures:
+    - php: 7.3
     - php: nightly
+
+  include:
+    - php: 7.1
+      env: PHPCS=1 COVERAGE=1 PHPSTAN=0
+    - php: 7.2
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+    - php: 7.3
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+    - php: nightly
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
 
 install:
   - composer validate --strict
   - composer install --no-interaction --no-progress --no-suggest
-  - mkdir -p build/logs
+  - mkdir -p build/test-coverage build/test-results
 
 before_script:
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE IF NOT EXISTS cakephp_test DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;'; fi"
 
 script:
-  - vendor/bin/phpcs
-  - if [ $TRAVIS_PHP_VERSION != "7.1" ]; then vendor/bin/phpunit --no-coverage; else vendor/bin/phpunit; fi
+  - if [[ $PHPCS = 1 ]]; then ./vendor/bin/phpcs; fi
+  - if [[ $COVERAGE = 0 ]]; then ./vendor/bin/phpunit --no-coverage; fi
+  - if [[ $COVERAGE = 1 ]]; then ./vendor/bin/phpunit; fi
+  - if [[ $PHPSTAN = 1 ]]; then ./vendor/bin/phpstan analyse; fi
 
 after_success:
   - curl -s https://codecov.io/bash > /tmp/codecov.sh
   - chmod +x /tmp/codecov.sh
-  - /tmp/codecov.sh -s build/logs
+  - /tmp/codecov.sh -s build/test-results
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,13 @@ matrix:
 
   include:
     - php: 7.1
-      env: PHPCS=1 COVERAGE=1 PHPSTAN=0
+      env: PHPCS=1 COVERAGE=1 PHPSTAN=1
     - php: 7.2
-      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=1
     - php: 7.3
-      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=1
     - php: nightly
-      env: PHPCS=1 COVERAGE=0 PHPSTAN=0
+      env: PHPCS=1 COVERAGE=0 PHPSTAN=1
 
 install:
   - composer validate --strict

--- a/composer.json
+++ b/composer.json
@@ -1,35 +1,58 @@
 {
     "name": "qobo/cakephp-messaging-center",
     "description": "Messaging Center plugin for CakePHP",
+    "keywords": ["cakephp", "messages"],
     "type": "cakephp-plugin",
-	"license": "MIT",
-	"authors": [
-		{
-			"name": "Qobo Ltd",
-			"email": "info@qobo.biz",
-			"homepage": "https://www.qobo.biz",
-			"role": "Developer"
-		}
-	],
+    "license": "MIT",
+    "homepage": "https://www.qobo.biz",
+    "authors": [
+        {
+            "name": "Qobo Ltd",
+            "email": "support@qobo.biz",
+            "homepage": "https://www.qobo.biz",
+            "role": "Developer"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/QoboLtd/cakephp-messaging-center/issues",
+        "source": "https://github.com/QoboLtd/cakephp-messaging-center"
+    },
+    "config": {
+        "sort-packages": true,
+        "optimize-autoloader": true
+    },
     "require": {
-        "qobo/cakephp-utils": "^9.0"
+        "qobo/cakephp-utils": "^10.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
-        "cakephp/cakephp-codesniffer": "^3.0"
+        "qobo/cakephp-composer-dev": "^v1.0"
     },
     "autoload": {
         "psr-4": {
-            "MessagingCenter\\": "src",
-            "MessagingCenter\\Test\\Fixture\\": "tests\\Fixture",
-            "CakeDC\\Users\\Test\\Fixture\\": "tests"
+            "MessagingCenter\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "MessagingCenter\\Test\\": "tests",
-            "CakeDC\\Users\\Test\\": "./vendor/cakedc/users/tests",
-            "Cake\\Test\\": "./vendor/cakephp/cakephp/tests"
+            "MessagingCenter\\Test\\": "tests/",
+            "CakeDC\\Users\\Test\\": "vendor/cakedc/users/tests/",
+            "Cake\\Test\\": "vendor/cakephp/cakephp/tests/"
         }
-    }
+    },
+    "scripts": {
+        "test": [
+            "phpcs",
+            "phpunit --no-coverage"
+        ],
+        "test-coverage": [
+            "phpcs",
+            "phpunit"
+        ],
+        "post-autoload-dump": "Cake\\Composer\\Installer\\PluginInstaller::postAutoloadDump"
+    },
+    "scripts-descriptions": {
+        "test": "Runs phpcs and phpunit without coverage",
+        "test-coverage": "Runs phpcs and phpunit with coverage enabled"
+    },
+    "prefer-stable": true
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,16 +9,15 @@
     <description>PHP CodeSniffer Configuration</description>
 
     <!-- Coding standard to use -->
-    <rule ref="./vendor/cakephp/cakephp-codesniffer/CakePHP" />
+    <rule ref="./vendor/cakephp/cakephp-codesniffer/CakePHP">
+        <exclude name="Generic.Commenting.Todo" />
+    </rule>
 
     <!-- Do not fail on warnings -->
     <config name="ignore_warnings_on_exit" value="1" />
 
     <!-- Assume UTF-8 -->
     <config name="encoding" value="UTF-8" />
-
-    <!-- Extensions to check -->
-    <arg name="extensions" value="php,inc,ctp,js,css" />
 
     <!-- Use colors -->
     <arg name="colors" />
@@ -29,7 +28,13 @@
     <!-- Files and directories to check -->
     <file>./src/</file>
     <file>./tests/</file>
+    <file>./config/</file>
     <file>./webroot/</file>
-    <!-- Files and directories to ignore -->
-    <arg name="ignore" value="webroot/js/bootstrap-typeahead.js" />
+
+    <!-- Exclude patterns -->
+    <exclude-pattern>webroot/js/bootstrap-typeahead.js</exclude-pattern>
+    <exclude-pattern>config/Migrations/*</exclude-pattern>
+    <exclude-pattern>config/Seeds/*</exclude-pattern>
+    <exclude-pattern>webroot/plugins/*</exclude-pattern>
+    <exclude-pattern>*\.min\.(css|js)</exclude-pattern>
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,14 @@
+parameters:
+    level: 7
+    paths:
+        - src
+        - tests
+        - webroot
+    autoload_files:
+        - tests/bootstrap.php
+    earlyTerminatingMethodCalls:
+        Cake\Console\Shell:
+            - abort
+includes:
+    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
+    - vendor/timeweb/phpstan-enum/extension.neon

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,31 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-	colors="true"
-	processIsolation="false"
-	stopOnFailure="false"
-	syntaxCheck="false"
-	bootstrap="./tests/bootstrap.php"
+    colors="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    bootstrap="./tests/bootstrap.php"
     verbose="true"
-	>
-	<php>
-		<ini name="memory_limit" value="-1"/>
-		<ini name="apc.enable_cli" value="1"/>
-	</php>
-
-	<filter>
-		<whitelist>
-            <directory suffix=".php">./src/</directory>
-            <directory suffix=".php">./webroot/</directory>
-		</whitelist>
-	</filter>
+    >
+    <php>
+        <ini name="memory_limit" value="-1"/>
+        <ini name="apc.enable_cli" value="1"/>
+    </php>
 
     <logging>
-		<log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
-		<log type="coverage-html" target="build/coverage"/>
-		<log type="coverage-clover" target="build/logs/clover.xml"/>
-		<log type="coverage-crap4j" target="build/logs/crap4j.xml"/>
-		<log type="junit" target="build/logs/junit.xml"/>
+        <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
+        <log type="coverage-html" target="build/test-coverage"/>
+        <log type="coverage-clover" target="build/test-results/clover.xml"/>
+        <log type="coverage-crap4j" target="build/test-results/crap4j.xml"/>
+        <log type="junit" target="build/test-results/junit.xml"/>
     </logging>
+
+    <!-- Add any additional test suites you want to run here -->
+    <testsuites>
+        <testsuite name="messages">
+            <directory>tests/TestCase</directory>
+        </testsuite>
+    </testsuites>
 
     <!-- Setup a listener for fixtures -->
     <listeners>
@@ -38,11 +37,11 @@
         </listener>
     </listeners>
 
-    <!-- Add any additional test suites you want to run here -->
-    <testsuites>
-        <testsuite name="MessagingCenter Test Suite">
-            <directory>./tests/TestCase</directory>
-        </testsuite>
-    </testsuites>
-
+    <!-- Ignore vendor tests in code coverage reports -->
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./src/</directory>
+            <directory suffix=".php">./webroot/</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/Controller/MessagesController.php
+++ b/src/Controller/MessagesController.php
@@ -25,9 +25,9 @@ class MessagesController extends AppController
     /**
      * Folder method
      * @param string $folder folder name
-     * @return void
+     * @return \Cake\Http\Response|void|null
      */
-    public function folder($folder = '')
+    public function folder(string $folder = '')
     {
         if (!$this->Messages->folderExists($folder)) {
             $folder = $this->Messages->getDefaultFolder();
@@ -48,11 +48,13 @@ class MessagesController extends AppController
      * View method
      *
      * @param string|null $id Message id.
-     * @return void
-     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+     * @return \Cake\Http\Response|void|null
      */
-    public function view($id = null)
+    public function view(string $id = null)
     {
+        /**
+         * @var \MessagingCenter\Model\Entity\Message $message
+         */
         $message = $this->Messages->get($id, [
             'contain' => ['FromUser', 'ToUser']
         ]);
@@ -95,11 +97,11 @@ class MessagesController extends AppController
             $data['date_sent'] = $this->Messages->getDateSent();
             $message = $this->Messages->patchEntity($message, $data);
             if ($this->Messages->save($message)) {
-                $this->Flash->success(__('The message has been sent.'));
+                $this->Flash->success((string)__('The message has been sent.'));
 
                 return $this->redirect(['action' => 'folder']);
             } else {
-                $this->Flash->error(__('The message could not be sent. Please, try again.'));
+                $this->Flash->error((string)__('The message could not be sent. Please, try again.'));
             }
         }
 
@@ -112,15 +114,18 @@ class MessagesController extends AppController
      * @param string $id message id
      * @return \Cake\Http\Response|void|null Redirects on successful reply, renders view otherwise.
      */
-    public function reply($id)
+    public function reply(string $id)
     {
+        /**
+         * @var \MessagingCenter\Model\Entity\Message $message
+         */
         $message = $this->Messages->get($id, [
             'contain' => ['FromUser', 'ToUser']
         ]);
 
         // current user's sent message
         if ($this->Auth->user('id') !== $message->to_user) {
-            $this->Flash->error(__('You cannot reply to a sent message.'));
+            $this->Flash->error((string)__('You cannot reply to a sent message.'));
 
             return $this->redirect(['action' => 'view', $id]);
         }
@@ -135,11 +140,11 @@ class MessagesController extends AppController
             $data['related_id'] = $id;
             $newMessage = $this->Messages->patchEntity($newMessage, $data);
             if ($this->Messages->save($newMessage)) {
-                $this->Flash->success(__('The message has been sent.'));
+                $this->Flash->success((string)__('The message has been sent.'));
 
                 return $this->redirect(['action' => 'folder']);
             } else {
-                $this->Flash->error(__('The message could not be sent. Please, try again.'));
+                $this->Flash->error((string)__('The message could not be sent. Please, try again.'));
             }
         }
 
@@ -153,23 +158,26 @@ class MessagesController extends AppController
      * @param string|null $id Message id.
      * @return \Cake\Http\Response|void|null Redirects to folder.
      */
-    public function delete($id = null)
+    public function delete(string $id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
+        /**
+         * @var \MessagingCenter\Model\Entity\Message $message
+         */
         $message = $this->Messages->get($id);
 
         $status = $this->Messages->getDeletedStatus();
 
         // already deleted message
         if ($message->status === $status) {
-            $this->Flash->error(__('You cannot delete a deleted message.'));
+            $this->Flash->error((string)__('You cannot delete a deleted message.'));
 
             return $this->redirect(['action' => 'view', $id]);
         }
 
         // current user's sent message
         if ($this->Auth->user('id') !== $message->to_user) {
-            $this->Flash->error(__('You cannot delete a sent message.'));
+            $this->Flash->error((string)__('You cannot delete a sent message.'));
 
             return $this->redirect(['action' => 'view', $id]);
         }
@@ -177,9 +185,9 @@ class MessagesController extends AppController
         $message = $this->Messages->patchEntity($message, ['status' => $status]);
 
         if ($this->Messages->save($message)) {
-            $this->Flash->success(__('The message has been deleted.'));
+            $this->Flash->success((string)__('The message has been deleted.'));
         } else {
-            $this->Flash->error(__('The message could not be deleted. Please, try again.'));
+            $this->Flash->error((string)__('The message could not be deleted. Please, try again.'));
         }
 
         return $this->redirect(['action' => 'folder']);
@@ -191,22 +199,25 @@ class MessagesController extends AppController
      * @param string|null $id Message id.
      * @return \Cake\Http\Response|void|null Redirects to folder.
      */
-    public function archive($id = null)
+    public function archive(string $id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
+        /**
+         * @var \MessagingCenter\Model\Entity\Message $message
+         */
         $message = $this->Messages->get($id);
 
         $status = $this->Messages->getArchivedStatus();
 
         // current user's sent message
         if ($this->Auth->user('id') !== $message->to_user) {
-            $this->Flash->error(__('You cannot archive a sent message.'));
+            $this->Flash->error((string)__('You cannot archive a sent message.'));
 
             return $this->redirect(['action' => 'view', $id]);
         } else {
             // already archived message
             if ($message->status === $status) {
-                $this->Flash->error(__('You cannot arcive an archived message.'));
+                $this->Flash->error((string)__('You cannot arcive an archived message.'));
 
                 return $this->redirect(['action' => 'view', $id]);
             }
@@ -215,9 +226,9 @@ class MessagesController extends AppController
         $message = $this->Messages->patchEntity($message, ['status' => $status]);
 
         if ($this->Messages->save($message)) {
-            $this->Flash->success(__('The message has been archived.'));
+            $this->Flash->success((string)__('The message has been archived.'));
         } else {
-            $this->Flash->error(__('The message could not be archived. Please, try again.'));
+            $this->Flash->error((string)__('The message could not be archived. Please, try again.'));
         }
 
         return $this->redirect(['action' => 'folder']);
@@ -229,22 +240,25 @@ class MessagesController extends AppController
      * @param string|null $id Message id.
      * @return \Cake\Http\Response|void|null Redirects to folder.
      */
-    public function restore($id = null)
+    public function restore(string $id = null)
     {
         $this->request->allowMethod(['post', 'delete']);
+        /**
+         * @var \MessagingCenter\Model\Entity\Message $message
+         */
         $message = $this->Messages->get($id);
 
         $status = $this->Messages->getReadStatus();
 
         // current user's sent message
         if ($this->Auth->user('id') !== $message->to_user) {
-            $this->Flash->error(__('You cannot restore a sent message.'));
+            $this->Flash->error((string)__('You cannot restore a sent message.'));
 
             return $this->redirect(['action' => 'view', $id]);
         } else {
             // inbox message
             if (in_array($message->status, [$status, $this->Messages->getNewStatus()])) {
-                $this->Flash->error(__('You cannot restore an inbox message.'));
+                $this->Flash->error((string)__('You cannot restore an inbox message.'));
 
                 return $this->redirect(['action' => 'view', $id]);
             }
@@ -253,9 +267,9 @@ class MessagesController extends AppController
         $message = $this->Messages->patchEntity($message, ['status' => $status]);
 
         if ($this->Messages->save($message)) {
-            $this->Flash->success(__('The message has been restored.'));
+            $this->Flash->success((string)__('The message has been restored.'));
         } else {
-            $this->Flash->error(__('The message could not be restored. Please, try again.'));
+            $this->Flash->error((string)__('The message could not be restored. Please, try again.'));
         }
 
         return $this->redirect(['action' => 'folder']);

--- a/src/Controller/MessagesController.php
+++ b/src/Controller/MessagesController.php
@@ -11,7 +11,7 @@
  */
 namespace MessagingCenter\Controller;
 
-use Cake\Network\Exception\ForbiddenException;
+use Cake\Http\Exception\ForbiddenException;
 use MessagingCenter\Controller\AppController;
 
 /**
@@ -83,16 +83,17 @@ class MessagesController extends AppController
     /**
      * Composer method
      *
-     * @return \Cake\Network\Response|void Redirects on successful compose, renders view otherwise.
+     * @return \Cake\Http\Response|void|null Redirects on successful compose, renders view otherwise.
      */
     public function compose()
     {
         $message = $this->Messages->newEntity();
         if ($this->request->is('post')) {
-            $this->request->data['from_user'] = $this->Auth->user('id');
-            $this->request->data['status'] = $this->Messages->getNewStatus();
-            $this->request->data['date_sent'] = $this->Messages->getDateSent();
-            $message = $this->Messages->patchEntity($message, $this->request->data);
+            $data = $this->request->getData();
+            $data['from_user'] = $this->Auth->user('id');
+            $data['status'] = $this->Messages->getNewStatus();
+            $data['date_sent'] = $this->Messages->getDateSent();
+            $message = $this->Messages->patchEntity($message, $data);
             if ($this->Messages->save($message)) {
                 $this->Flash->success(__('The message has been sent.'));
 
@@ -109,7 +110,7 @@ class MessagesController extends AppController
     /**
      * Reply method
      * @param string $id message id
-     * @return \Cake\Network\Response|void Redirects on successful reply, renders view otherwise.
+     * @return \Cake\Http\Response|void|null Redirects on successful reply, renders view otherwise.
      */
     public function reply($id)
     {
@@ -126,12 +127,13 @@ class MessagesController extends AppController
 
         if ($this->request->is('put')) {
             $newMessage = $this->Messages->newEntity();
-            $this->request->data['to_user'] = $message->from_user;
-            $this->request->data['from_user'] = $this->Auth->user('id');
-            $this->request->data['status'] = $this->Messages->getNewStatus();
-            $this->request->data['date_sent'] = $this->Messages->getDateSent();
-            $this->request->data['related_id'] = $id;
-            $newMessage = $this->Messages->patchEntity($newMessage, $this->request->data);
+            $data = $this->request->getData();
+            $data['to_user'] = $message->from_user;
+            $data['from_user'] = $this->Auth->user('id');
+            $data['status'] = $this->Messages->getNewStatus();
+            $data['date_sent'] = $this->Messages->getDateSent();
+            $data['related_id'] = $id;
+            $newMessage = $this->Messages->patchEntity($newMessage, $data);
             if ($this->Messages->save($newMessage)) {
                 $this->Flash->success(__('The message has been sent.'));
 
@@ -149,8 +151,7 @@ class MessagesController extends AppController
      * Delete method
      *
      * @param string|null $id Message id.
-     * @return \Cake\Network\Response|null Redirects to folder.
-     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+     * @return \Cake\Http\Response|void|null Redirects to folder.
      */
     public function delete($id = null)
     {
@@ -188,8 +189,7 @@ class MessagesController extends AppController
      * Archive method
      *
      * @param string|null $id Message id.
-     * @return \Cake\Network\Response|null Redirects to folder.
-     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+     * @return \Cake\Http\Response|void|null Redirects to folder.
      */
     public function archive($id = null)
     {
@@ -227,8 +227,7 @@ class MessagesController extends AppController
      * Restore method
      *
      * @param string|null $id Message id.
-     * @return \Cake\Network\Response|null Redirects to folder.
-     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+     * @return \Cake\Http\Response|void|null Redirects to folder.
      */
     public function restore($id = null)
     {

--- a/src/Event/Model/UserListener.php
+++ b/src/Event/Model/UserListener.php
@@ -54,7 +54,7 @@ class UserListener implements EventListenerInterface
      */
     public function afterSave(Event $event, EntityInterface $entity, ArrayObject $options)
     {
-        if ($event->subject()->getTable() !== $this->getUsersTable()->getTable()) {
+        if ($event->getSubject()->getTable() !== $this->getUsersTable()->getTable()) {
             return;
         }
 
@@ -91,7 +91,7 @@ class UserListener implements EventListenerInterface
             'entity' => $entity,
             'data' => $data
         ]);
-        $this->eventManager()->dispatch($event);
+        $this->getEventManager()->dispatch($event);
         $data = !empty($event->result) ? $event->result : $data;
 
         $this->Notifier->subject($subject);

--- a/src/Event/Model/UserListener.php
+++ b/src/Event/Model/UserListener.php
@@ -52,9 +52,13 @@ class UserListener implements EventListenerInterface
      * @param \ArrayObject $options options.
      * @return void
      */
-    public function afterSave(Event $event, EntityInterface $entity, ArrayObject $options)
+    public function afterSave(Event $event, EntityInterface $entity, ArrayObject $options): void
     {
-        if ($event->getSubject()->getTable() !== $this->getUsersTable()->getTable()) {
+        /**
+         * @var \Cake\ORM\Table $subject
+         */
+        $subject = $event->getSubject();
+        if ($subject->getTable() !== $this->getUsersTable()->getTable()) {
             return;
         }
 
@@ -77,8 +81,10 @@ class UserListener implements EventListenerInterface
             $subject .= ' to ' . $projectName;
         }
 
+        // TODO: find a better way
+        $username = empty($entity->username) ? '' : $entity->username;
         $data = [
-            'username' => $entity->username,
+            'username' => $username,
             'projectName' => $projectName,
             'subject' => $subject,
             'adminName' => Configure::readOrFail('MessagingCenter.systemUser.name'),

--- a/src/Model/Behavior/NotifyBehavior.php
+++ b/src/Model/Behavior/NotifyBehavior.php
@@ -80,8 +80,8 @@ class NotifyBehavior extends Behavior
         parent::initialize($config);
 
         // merge with default ignored fields
-        if (!empty($this->config('ignoredFields'))) {
-            $this->_ignoredModifyFields = array_merge($this->_ignoredModifyFields, $this->config('ignoredFields'));
+        if (!empty($this->getConfig('ignoredFields'))) {
+            $this->_ignoredModifyFields = array_merge($this->_ignoredModifyFields, $this->getConfig('ignoredFields'));
         }
 
         $this->_fromUser = Configure::readOrFail('MessagingCenter.systemUser.id');
@@ -97,7 +97,7 @@ class NotifyBehavior extends Behavior
     public function afterSave(Event $event, EntityInterface $entity, ArrayObject $options)
     {
         // nothing has been modified
-        if (!$entity->dirty()) {
+        if (!$entity->isDirty()) {
             return;
         }
 
@@ -108,7 +108,7 @@ class NotifyBehavior extends Behavior
             return;
         }
 
-        $notifyFields = $this->_getNotifyFields($event->subject());
+        $notifyFields = $this->_getNotifyFields($event->getSubject());
         // no notify fields have been found
         if (empty($notifyFields)) {
             return;
@@ -121,7 +121,7 @@ class NotifyBehavior extends Behavior
         }
 
         foreach ($notifyFields as $notifyField) {
-            $this->_notifyUser($notifyField, $entity, $event->subject(), $modifiedFields);
+            $this->_notifyUser($notifyField, $entity, $event->getSubject(), $modifiedFields);
         }
     }
 
@@ -174,15 +174,15 @@ class NotifyBehavior extends Behavior
     {
         $result = [];
         foreach ($table->associations() as $association) {
-            if ($association->className() !== $this->_usersTable->alias()) {
+            if ($association->className() !== $this->_usersTable->getAlias()) {
                 continue;
             }
 
-            if (in_array($association->foreignKey(), $this->_ignoredModifyFields)) {
+            if (in_array($association->getForeignKey(), $this->_ignoredModifyFields)) {
                 continue;
             }
 
-            $result[] = $association->foreignKey();
+            $result[] = $association->getForeignKey();
         }
 
         return $result;
@@ -245,7 +245,7 @@ class NotifyBehavior extends Behavior
             'entity' => $entity,
             'data' => $data
         ]);
-        $this->eventManager()->dispatch($event);
+        $this->getEventManager()->dispatch($event);
         $data = !empty($event->result) ? $event->result : $data;
 
         $this->Notifier->subject($data['modelName'] . ': ' . $data['recordName']);
@@ -266,8 +266,8 @@ class NotifyBehavior extends Behavior
     protected function _getData($field, EntityInterface $entity, Table $table, array $modifiedFields)
     {
         return [
-            'modelName' => Inflector::singularize(Inflector::humanize(Inflector::underscore($table->table()))),
-            'registryAlias' => $table->registryAlias(),
+            'modelName' => Inflector::singularize(Inflector::humanize(Inflector::underscore($table->getTable()))),
+            'registryAlias' => $table->getRegistryAlias(),
             'recordId' => $entity->get($table->getPrimaryKey()),
             'recordName' => $entity->get($table->getDisplayField()),
             'field' => Inflector::humanize($field),

--- a/src/Model/Behavior/NotifyBehavior.php
+++ b/src/Model/Behavior/NotifyBehavior.php
@@ -92,9 +92,14 @@ class NotifyBehavior extends Behavior
     }
 
     /**
-     * {@inheritDoc}
+     * afterSave event
+     *
+     * @param \Cake\Event\Event $event Event
+     * @param \Cake\Datasource\EntityInterface $entity Entity
+     * @param \ArrayObject $options Options
+     * @return void
      */
-    public function afterSave(Event $event, EntityInterface $entity, ArrayObject $options)
+    public function afterSave(Event $event, EntityInterface $entity, ArrayObject $options): void
     {
         // nothing has been modified
         if (!$entity->isDirty()) {
@@ -108,7 +113,12 @@ class NotifyBehavior extends Behavior
             return;
         }
 
-        $notifyFields = $this->_getNotifyFields($event->getSubject());
+        /**
+         * @var \Cake\ORM\Table $subject
+         */
+        $subject = $event->getSubject();
+
+        $notifyFields = $this->_getNotifyFields($subject);
         // no notify fields have been found
         if (empty($notifyFields)) {
             return;
@@ -121,7 +131,7 @@ class NotifyBehavior extends Behavior
         }
 
         foreach ($notifyFields as $notifyField) {
-            $this->_notifyUser($notifyField, $entity, $event->getSubject(), $modifiedFields);
+            $this->_notifyUser($notifyField, $entity, $subject, $modifiedFields);
         }
     }
 
@@ -133,9 +143,9 @@ class NotifyBehavior extends Behavior
      * _ignoreFields array.
      *
      * @param \Cake\Datasource\EntityInterface $entity Entity object
-     * @return array
+     * @return mixed[]
      */
-    protected function _getModifiedFields(EntityInterface $entity)
+    protected function _getModifiedFields(EntityInterface $entity): array
     {
         if ($entity->isNew()) {
             $fields = $entity->extractOriginal($entity->visibleProperties());
@@ -168,9 +178,9 @@ class NotifyBehavior extends Behavior
      * Get notify fields based on current table's associations.
      *
      * @param \Cake\ORM\Table $table Table instance
-     * @return array
+     * @return mixed[]
      */
-    protected function _getNotifyFields(Table $table)
+    protected function _getNotifyFields(Table $table): array
     {
         $result = [];
         foreach ($table->associations() as $association) {
@@ -191,11 +201,11 @@ class NotifyBehavior extends Behavior
     /**
      * Filter out notify fields that have not been modified or their value is currently empty.
      *
-     * @param  array $notifyFields Notify fields
+     * @param  mixed[] $notifyFields Notify fields
      * @param \Cake\Datasource\EntityInterface $entity Entity object
-     * @return array
+     * @return mixed[]
      */
-    protected function _filterNotifyFields(array $notifyFields, EntityInterface $entity)
+    protected function _filterNotifyFields(array $notifyFields, EntityInterface $entity): array
     {
         $result = [];
         foreach ($notifyFields as $notifyField) {
@@ -215,9 +225,9 @@ class NotifyBehavior extends Behavior
      *
      * @param string $field Notify field
      * @param \Cake\Datasource\EntityInterface $entity Entity object
-     * @return array
+     * @return string
      */
-    protected function _getTemplate($field, EntityInterface $entity)
+    protected function _getTemplate(string $field, EntityInterface $entity): string
     {
         return $entity->isDirty($field) ? 'MessagingCenter.record_link' : 'MessagingCenter.record_modified';
     }
@@ -228,10 +238,10 @@ class NotifyBehavior extends Behavior
      * @param string $field Field name
      * @param \Cake\Datasource\EntityInterface $entity Entity object
      * @param \Cake\ORM\Table $table Table instance
-     * @param array $modifiedFields Entity's modified fields (includes old and new values)
+     * @param mixed[] $modifiedFields Entity's modified fields (includes old and new values)
      * @return void
      */
-    protected function _notifyUser($field, EntityInterface $entity, Table $table, array $modifiedFields)
+    protected function _notifyUser(string $field, EntityInterface $entity, Table $table, array $modifiedFields): void
     {
         $this->Notifier->from($this->_fromUser);
         $this->Notifier->to($entity->get($field));
@@ -260,15 +270,20 @@ class NotifyBehavior extends Behavior
      * @param string $field Field name
      * @param \Cake\Datasource\EntityInterface $entity Entity object
      * @param \Cake\ORM\Table $table Table instance
-     * @param array $modifiedFields Entity's modified fields (includes old and new values)
-     * @return array
+     * @param mixed[] $modifiedFields Entity's modified fields (includes old and new values)
+     * @return mixed[]
      */
-    protected function _getData($field, EntityInterface $entity, Table $table, array $modifiedFields)
+    protected function _getData(string $field, EntityInterface $entity, Table $table, array $modifiedFields): array
     {
+        /**
+         * @var string $primaryKey
+         */
+        $primaryKey = $table->getPrimaryKey();
+
         return [
             'modelName' => Inflector::singularize(Inflector::humanize(Inflector::underscore($table->getTable()))),
             'registryAlias' => $table->getRegistryAlias(),
-            'recordId' => $entity->get($table->getPrimaryKey()),
+            'recordId' => $entity->get($primaryKey),
             'recordName' => $entity->get($table->getDisplayField()),
             'field' => Inflector::humanize($field),
             'modifiedFields' => $modifiedFields

--- a/src/Model/Table/MessagesTable.php
+++ b/src/Model/Table/MessagesTable.php
@@ -46,9 +46,9 @@ class MessagesTable extends Table
     {
         parent::initialize($config);
 
-        $this->table('qobo_messages');
-        $this->displayField('id');
-        $this->primaryKey('id');
+        $this->setTable('qobo_messages');
+        $this->setDisplayField('id');
+        $this->setPrimaryKey('id');
 
         $this->addBehavior('Timestamp');
 

--- a/src/Model/Table/MessagesTable.php
+++ b/src/Model/Table/MessagesTable.php
@@ -114,54 +114,60 @@ class MessagesTable extends Table
 
     /**
      * Returns string to be used as status field value when a new message is created.
+     *
      * @return string
      */
-    public function getNewStatus()
+    public function getNewStatus(): string
     {
         return static::STATUS_NEW;
     }
 
     /**
      * Returns string to be used as status field value when a message is read.
+     *
      * @return string
      */
-    public function getReadStatus()
+    public function getReadStatus(): string
     {
         return static::STATUS_READ;
     }
 
     /**
      * Returns string to be used as status field value when a message is deleted.
+     *
      * @return string
      */
-    public function getDeletedStatus()
+    public function getDeletedStatus(): string
     {
         return static::STATUS_DELETED;
     }
 
     /**
      * Returns string to be used as status field value when a message is archived.
+     *
      * @return string
      */
-    public function getArchivedStatus()
+    public function getArchivedStatus(): string
     {
         return static::STATUS_ARCHIVED;
     }
 
     /**
      * Returns sent folder name.
+     *
      * @return string
      */
-    public function getSentFolder()
+    public function getSentFolder(): string
     {
         return static::FOLDER_SENT;
     }
 
     /**
      * Returns Time object to be used as date_sent field value.
+     *
      * @return \Cake\I18n\Time
      */
-    public function getDateSent()
+    public function getDateSent(): \Cake\I18n\Time
     {
         $result = new Time();
 
@@ -170,18 +176,20 @@ class MessagesTable extends Table
 
     /**
      * Method that returns default folder's name.
+     *
      * @return string
      */
-    public function getDefaultFolder()
+    public function getDefaultFolder(): string
     {
         return static::FOLDER_INBOX;
     }
 
     /**
      * Method that returns all folder names.
-     * @return array
+     *
+     * @return string[]
      */
-    public function getFolders()
+    public function getFolders(): array
     {
         $result = [
             static::FOLDER_INBOX,
@@ -198,7 +206,7 @@ class MessagesTable extends Table
      * @param  string $folder folder name
      * @return bool
      */
-    public function folderExists($folder = '')
+    public function folderExists(string $folder = ''): bool
     {
         if (!in_array($folder, $this->getFolders())) {
             return false;
@@ -215,7 +223,7 @@ class MessagesTable extends Table
      * @param  string $referer http referer
      * @return string         folder name
      */
-    public function getFolderByMessage(Message $message, $userId, $referer = '')
+    public function getFolderByMessage(Message $message, string $userId, string $referer = ''): string
     {
         $result = substr($referer, strrpos($referer, '/') + 1);
 
@@ -248,9 +256,9 @@ class MessagesTable extends Table
      * Get query conditions based on folder type.
      * @param  string $userId current user id
      * @param  string $folder folder
-     * @return array          query conditions
+     * @return mixed[]          query conditions
      */
-    public function getConditionsByFolder($userId, $folder = '')
+    public function getConditionsByFolder(string $userId, string $folder = ''): array
     {
         switch ($folder) {
             case 'archived':

--- a/src/Notifier/MessageNotifier.php
+++ b/src/Notifier/MessageNotifier.php
@@ -13,19 +13,16 @@ namespace MessagingCenter\Notifier;
 
 use Cake\I18n\Time;
 use Cake\ORM\TableRegistry;
-use Cake\View\ViewVarsTrait;
 use InvalidArgumentException;
 
 class MessageNotifier extends Notifier
 {
-    use ViewVarsTrait;
-
     /**
      * Messages Table instance.
      *
-     * @var \Cake\ORM\Table
+     * @var \MessagingCenter\Model\Table\MessagesTable $_table
      */
-    protected $_table = null;
+    protected $_table;
 
     /**
      * Notification status.
@@ -68,12 +65,15 @@ class MessageNotifier extends Notifier
     ];
 
     /**
-     * {@inheritDoc}
+     * Constructor
      */
     public function __construct()
     {
-        // set table instance
-        $this->_table = TableRegistry::get('MessagingCenter.Messages');
+        /**
+         * @var \MessagingCenter\Model\Table\MessagesTable $table
+         */
+        $table = TableRegistry::get('MessagingCenter.Messages');
+        $this->_table = $table;
 
         // set properties
         $this->_dateSent = new Time();
@@ -87,23 +87,31 @@ class MessageNotifier extends Notifier
     }
 
     /**
-     * {@inheritDoc}
+     * Message template setter.
+     *
+     * @param  string $template Template name
+     * @return void
      */
-    public function template($template = 'MessagingCenter.record_link')
+    public function template(string $template): void
     {
+        if (empty($template)) {
+            $template = 'MessagingCenter.record_link';
+        }
         parent::template($template);
     }
 
     /**
-     * {@inheritDoc}
+     * Sends notification.
+     *
+     * @return void
      */
-    public function send()
+    public function send(): void
     {
         // validate message data
         $this->validate();
 
         $entity = $this->_table->newEntity();
-        $data = $this->_getMessageData();
+        $data = $this->getMessageData();
         $entity = $this->_table->patchEntity($entity, $data);
 
         $this->_table->save($entity);
@@ -112,9 +120,9 @@ class MessageNotifier extends Notifier
     /**
      * Extracts and returns notification message data from class properties.
      *
-     * @return array
+     * @return mixed[]
      */
-    protected function _getMessageData()
+    protected function getMessageData(): array
     {
         $data = [];
         foreach ($this->_propertyMap as $k => $v) {

--- a/src/Notifier/MessageNotifier.php
+++ b/src/Notifier/MessageNotifier.php
@@ -80,10 +80,10 @@ class MessageNotifier extends Notifier
         $this->_status = $this->_table->getNewStatus();
 
         $this->viewBuilder()
-            ->className('Cake\View\View')
-            ->template('')
-            ->layout('default')
-            ->helpers(['Html']);
+            ->setClassName('Cake\View\View')
+            ->setTemplate('')
+            ->setLayout('default')
+            ->setHelpers(['Html']);
     }
 
     /**

--- a/src/Notifier/Notifier.php
+++ b/src/Notifier/Notifier.php
@@ -13,10 +13,16 @@ namespace MessagingCenter\Notifier;
 
 use Cake\I18n\Time;
 use Cake\ORM\TableRegistry;
+use Cake\View\ViewVarsTrait;
 use InvalidArgumentException;
 
+/**
+ * @property \Cake\View\ViewBuilder $viewBuilder
+ */
 class Notifier implements NotifierInterface
 {
+    use ViewVarsTrait;
+
     /**
      * Notification From user.
      *
@@ -41,7 +47,7 @@ class Notifier implements NotifierInterface
     /**
      * Notification message.
      *
-     * @var string
+     * @var string|array
      */
     protected $_message;
 
@@ -58,19 +64,15 @@ class Notifier implements NotifierInterface
     ];
 
     /**
-     * {@inheritDoc}
+     * Message template setter.
+     *
+     * @throws \InvalidArgumentException when the template is empty
+     * @param  string $template Template name
+     * @return void
      */
-    public function __construct()
+    public function template(string $template): void
     {
-        //
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function template($template)
-    {
-        if (!$template) {
+        if (empty($template)) {
             throw new InvalidArgumentException('Template cannot be empty.');
         }
 
@@ -78,36 +80,48 @@ class Notifier implements NotifierInterface
     }
 
     /**
-     * {@inheritDoc}
+     * Notification from user setter.
+     *
+     * @param  string $from From user
+     * @return void
      */
-    public function from($from)
+    public function from(string $from): void
     {
         $this->_from = $from;
     }
 
     /**
-     * {@inheritDoc}
+     * Notification to user setter.
+     *
+     * @param  string $to To user
+     * @return void
      */
-    public function to($to)
+    public function to(string $to): void
     {
         $this->_to = $to;
     }
 
     /**
-     * {@inheritDoc}
+     * Notification subject setter.
+     *
+     * @param  string $subject Subject
+     * @return void
      */
-    public function subject($subject)
+    public function subject(string $subject): void
     {
         $this->_subject = $subject;
     }
 
     /**
-     * {@inheritDoc}
+     * Notification message setter.
+     *
+     * @param  string|array $message Message
+     * @return void
      */
-    public function message($message)
+    public function message($message): void
     {
         if (!$this->viewBuilder()->getTemplate()) {
-            $this->template();
+            $this->template('');
         }
 
         $View = $this->createView();
@@ -129,13 +143,19 @@ class Notifier implements NotifierInterface
             $View->set('content', $message);
         }
 
-        $this->_message = $View->render();
+        /**
+         * @var string $message
+         */
+        $message = $View->render();
+        $this->_message = $message;
     }
 
     /**
-     * {@inheritDoc}
+     * Sends notification.
+     *
+     * @return void
      */
-    public function send()
+    public function send(): void
     {
         // validate notification data
         $this->validate();
@@ -144,9 +164,12 @@ class Notifier implements NotifierInterface
     }
 
     /**
-     * {@inheritDoc}
+     * Validate notification data.
+     *
+     * @throws \InvalidArgumentException when validation fails
+     * @return void
      */
-    public function validate()
+    public function validate(): void
     {
         // check for empty values
         foreach ($this->_requiredFields as $field) {

--- a/src/Notifier/Notifier.php
+++ b/src/Notifier/Notifier.php
@@ -74,7 +74,7 @@ class Notifier implements NotifierInterface
             throw new InvalidArgumentException('Template cannot be empty.');
         }
 
-        $this->viewBuilder()->template($template);
+        $this->viewBuilder()->setTemplate($template);
     }
 
     /**
@@ -106,20 +106,20 @@ class Notifier implements NotifierInterface
      */
     public function message($message)
     {
-        if (!$this->viewBuilder()->template()) {
+        if (!$this->viewBuilder()->getTemplate()) {
             $this->template();
         }
 
         $View = $this->createView();
 
-        list($plugin) = pluginSplit($View->template());
+        list($plugin) = pluginSplit($View->getTemplate());
         if ($plugin) {
             $View->plugin = $plugin;
         }
 
         $View->hasRendered = false;
-        $View->templatePath('Notifier');
-        $View->layoutPath('Notifier');
+        $View->setTemplatePath('Notifier');
+        $View->setLayoutPath('Notifier');
 
         if (is_array($message)) {
             foreach ($message as $k => $v) {

--- a/src/Notifier/NotifierInterface.php
+++ b/src/Notifier/NotifierInterface.php
@@ -14,33 +14,26 @@ namespace MessagingCenter\Notifier;
 interface NotifierInterface
 {
     /**
-     * Constructor method.
-     */
-    public function __construct();
-
-    /**
      * Sends notification.
      *
      * @return void
      */
-    public function send();
+    public function send(): void;
 
     /**
      * Validate notification data.
      *
-     * @throws InvalidArgumentException
      * @return void
      */
-    public function validate();
+    public function validate(): void;
 
     /**
      * Message template setter.
      *
      * @param  string $template Template name
-     * @throws InvalidArgumentException
      * @return void
      */
-    public function template($template);
+    public function template(string $template): void;
 
     /**
      * Notification from user setter.
@@ -48,7 +41,7 @@ interface NotifierInterface
      * @param  string $from From user
      * @return void
      */
-    public function from($from);
+    public function from(string $from): void;
 
     /**
      * Notification to user setter.
@@ -56,7 +49,7 @@ interface NotifierInterface
      * @param  string $to To user
      * @return void
      */
-    public function to($to);
+    public function to(string $to): void;
 
     /**
      * Notification subject setter.
@@ -64,13 +57,13 @@ interface NotifierInterface
      * @param  string $subject Subject
      * @return void
      */
-    public function subject($subject);
+    public function subject(string $subject): void;
 
     /**
      * Notification message setter.
      *
-     * @param  string $message Message
+     * @param  string|array $message Message
      * @return void
      */
-    public function message($message);
+    public function message($message): void;
 }

--- a/src/Template/Element/folders_list.ctp
+++ b/src/Template/Element/folders_list.ctp
@@ -30,7 +30,7 @@ $actions = [
 ];
 
 if (!isset($folder)) {
-    $folder = isset($this->request->params['pass'][0]) ? $this->request->params['pass'][0] : 'inbox';
+    $folder = $this->request->getParam('pass.0') ? $this->request->getParam('pass.0') : 'inbox';
 }
 ?>
 <div class="box box-primary">

--- a/src/Template/Messages/compose.ctp
+++ b/src/Template/Messages/compose.ctp
@@ -56,7 +56,7 @@ $unreadCount = (int)$this->cell('MessagingCenter.Inbox::unreadCount', ['{{text}}
                 <?= $this->Form->create($message); ?>
                 <div class="box-body">
                 <?php
-                echo $this->Form->input('to_user', [
+                echo $this->Form->control('to_user', [
                     'label' => false,
                     'name' => 'to_user_label',
                     'id' => 'to_user_label',
@@ -67,9 +67,9 @@ $unreadCount = (int)$this->cell('MessagingCenter.Inbox::unreadCount', ['{{text}}
                     'placeholder' => 'To:',
                     'data-url' => '/api/users/lookup.json'
                 ]);
-                echo $this->Form->input('to_user', ['type' => 'hidden']);
-                echo $this->Form->input('subject', ['label' => false, 'placeholder' => 'Subject:']);
-                echo $this->Form->input('content', ['label' => false, 'placeholder' => 'Message:']);
+                echo $this->Form->control('to_user', ['type' => 'hidden']);
+                echo $this->Form->control('subject', ['label' => false, 'placeholder' => 'Subject:']);
+                echo $this->Form->control('content', ['label' => false, 'placeholder' => 'Message:']);
                 ?>
                 </div>
                 <div class="box-footer">

--- a/src/Template/Messages/folder.ctp
+++ b/src/Template/Messages/folder.ctp
@@ -42,7 +42,7 @@ $unreadCount = (int)$this->cell('MessagingCenter.Inbox::unreadCount', ['{{text}}
                 </div>
                 <div class="box-body no-padding">
                     <div class="mailbox-controls">
-                        <a href="<?= $this->request->here; ?>" type="button" class="btn btn-default btn-sm">
+                        <a href="<?= $this->request->getAttribute('here'); ?>" type="button" class="btn btn-default btn-sm">
                             <i class="fa fa-refresh"></i>
                         </a>
                         <div class="pull-right">
@@ -117,7 +117,7 @@ $unreadCount = (int)$this->cell('MessagingCenter.Inbox::unreadCount', ['{{text}}
                 </div>
                 <div class="box-footer no-padding">
                     <div class="mailbox-controls">
-                        <a href="<?= $this->request->here; ?>" type="button" class="btn btn-default btn-sm">
+                        <a href="<?= $this->request->getAttribute('here'); ?>" type="button" class="btn btn-default btn-sm">
                             <i class="fa fa-refresh"></i>
                         </a>
                         <div class="pull-right">

--- a/src/Template/Messages/reply.ctp
+++ b/src/Template/Messages/reply.ctp
@@ -44,17 +44,17 @@ $username = $this->element('MessagingCenter.user', [
                 <?= $this->Form->create($message); ?>
                 <div class="box-body">
                 <?php
-                echo $this->Form->input('to_user_label', [
+                echo $this->Form->control('to_user_label', [
                     'value' => $username,
                     'label' => false,
                     'readonly' => true
                 ]);
-                echo $this->Form->input('subject', [
+                echo $this->Form->control('subject', [
                     'value' => 'Re: ' . $message->subject,
                     'label' => false,
                     'placeholder' => 'Subject:'
                 ]);
-                echo $this->Form->input('content', [
+                echo $this->Form->control('content', [
                     'value' => false,
                     'label' => false,
                     'placeholder' => 'Message:'

--- a/src/View/Cell/InboxCell.php
+++ b/src/View/Cell/InboxCell.php
@@ -32,7 +32,7 @@ class InboxCell extends Cell
      */
     public function unreadCount($format = '')
     {
-        $userId = $this->request->session()->read('Auth.User.id');
+        $userId = $this->request->getSession()->read('Auth.User.id');
         if ('' === trim($format)) {
             $format = static::UNREAD_COUNT_FORMAT;
         }
@@ -59,7 +59,7 @@ class InboxCell extends Cell
      */
     public function unreadMessages($limit = 10, $contentLength = 100)
     {
-        $userId = $this->request->session()->read('Auth.User.id');
+        $userId = $this->request->getSession()->read('Auth.User.id');
         $this->loadModel('MessagingCenter.Messages');
         $messages = $this->Messages->find('all', [
             'conditions' => [

--- a/src/View/Cell/InboxCell.php
+++ b/src/View/Cell/InboxCell.php
@@ -13,6 +13,9 @@ namespace MessagingCenter\View\Cell;
 
 use Cake\View\Cell;
 
+/**
+ * @property \MessagingCenter\Model\Table\MessagesTable $Messages
+ */
 class InboxCell extends Cell
 {
     /**
@@ -30,7 +33,7 @@ class InboxCell extends Cell
      * @param  string $format html format styling
      * @return void
      */
-    public function unreadCount($format = '')
+    public function unreadCount(string $format = ''): void
     {
         $userId = $this->request->getSession()->read('Auth.User.id');
         if ('' === trim($format)) {
@@ -46,7 +49,7 @@ class InboxCell extends Cell
         ]);
 
         $this->set('unreadFormat', $format);
-        $this->set('unreadCount', (int)$unread->count());
+        $this->set('unreadCount', $unread->count());
         $this->set('maxUnreadCount', static::MAX_UNREAD_COUNT);
     }
 
@@ -57,7 +60,7 @@ class InboxCell extends Cell
      * @param  int $contentLength content excerpt length
      * @return void
      */
-    public function unreadMessages($limit = 10, $contentLength = 100)
+    public function unreadMessages(int $limit = 10, int $contentLength = 100): void
     {
         $userId = $this->request->getSession()->read('Auth.User.id');
         $this->loadModel('MessagingCenter.Messages');
@@ -68,7 +71,7 @@ class InboxCell extends Cell
             ],
             'contain' => ['FromUser'],
             'order' => ['Messages.date_sent' => 'DESC'],
-            'limit' => (int)$limit
+            'limit' => $limit
         ]);
 
         $this->set(compact('messages', 'contentLength'));

--- a/tests/App/Application.php
+++ b/tests/App/Application.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link      https://cakephp.org CakePHP(tm) Project
+ * @since     3.3.0
+ * @license   https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace MessagingCenter\Test\App;
+
+use Cake\Core\Configure;
+use Cake\Error\Middleware\ErrorHandlerMiddleware;
+use Cake\Http\BaseApplication;
+use Cake\Routing\Middleware\AssetMiddleware;
+use Cake\Routing\Middleware\RoutingMiddleware;
+
+/**
+ * Application setup class.
+ *
+ * This defines the bootstrapping logic and middleware layers you
+ * want to use in your application.
+ */
+class Application extends BaseApplication
+{
+    /**
+     * Setup the middleware queue your application will use.
+     *
+     * @param \Cake\Http\MiddlewareQueue $middlewareQueue The middleware queue to setup.
+     * @return \Cake\Http\MiddlewareQueue The updated middleware queue.
+     */
+    public function middleware($middlewareQueue)
+    {
+        $middlewareQueue
+            // Catch any exceptions in the lower layers,
+            // and make an error page/response
+            ->add(ErrorHandlerMiddleware::class)
+
+            // Handle plugin/theme assets like CakePHP normally does.
+            ->add(AssetMiddleware::class)
+
+            // Add routing middleware.
+            ->add(new RoutingMiddleware($this));
+
+        return $middlewareQueue;
+    }
+}

--- a/tests/App/Controller/AppController.php
+++ b/tests/App/Controller/AppController.php
@@ -5,5 +5,16 @@ use \Cake\Controller\Controller;
 
 class AppController extends Controller
 {
-    public $components = ['Auth', 'Flash', 'RequestHandler'];
+    public function initialize()
+    {
+        parent::initialize();
+        $this->loadComponent('Auth', [
+            'authenticate' => ['Form']
+        ]);
+
+        $this->loadComponent('Flash');
+        $this->loadComponent('RequestHandler', [
+            'enableBeforeRedirect' => false,
+        ]);
+    }
 }

--- a/tests/App/Controller/UsersController.php
+++ b/tests/App/Controller/UsersController.php
@@ -1,14 +1,16 @@
 <?php
 namespace MessagingCenter\Test\App\Controller;
 
-use \Cake\Controller\Controller;
+use Cake\Controller\Controller;
 
 class UsersController extends Controller
 {
     /**
      * Simple users login action
+     *
+     * @return void
      */
-    public function login()
+    public function login(): void
     {
     }
 }

--- a/tests/App/Model/Entity/Article.php
+++ b/tests/App/Model/Entity/Article.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace MessagingCenter\Test\App\Model\Entity;
+
+use Cake\ORM\Entity;
+
+/**
+ * Article Entity.
+ *
+ * @property string $id
+ */
+class Article extends Entity
+{
+}

--- a/tests/App/Model/Table/ArticlesTable.php
+++ b/tests/App/Model/Table/ArticlesTable.php
@@ -1,0 +1,16 @@
+<?php
+namespace MessagingCenter\Test\App\Model\Table;
+
+use Cake\ORM\Table;
+
+class ArticlesTable extends Table
+{
+    public function initialize(array $config)
+    {
+        parent::initialize($config);
+
+        $this->setTable('articles');
+        $this->setPrimaryKey('id');
+        $this->setDisplayField('title');
+    }
+}

--- a/tests/TestCase/Controller/MessagesControllerTest.php
+++ b/tests/TestCase/Controller/MessagesControllerTest.php
@@ -24,6 +24,11 @@ class MessagesControllerTest extends IntegrationTestCase
     ];
 
     /**
+     * @var \MessagingCenter\Model\Table\MessagesTable $MessagesTable
+     */
+    protected $MessagesTable;
+
+    /**
      * setUp method
      *
      * @return void
@@ -32,7 +37,11 @@ class MessagesControllerTest extends IntegrationTestCase
     {
         parent::setUp();
 
-        $this->MessagesTable = TableRegistry::get('MessagingCenter.Messages');
+        /**
+         * @var \MessagingCenter\Model\Table\MessagesTable $table
+         */
+        $table = TableRegistry::get('MessagingCenter.Messages');
+        $this->MessagesTable = $table;
 
         $this->enableRetainFlashMessages();
         $this->session(['Auth.User.id' => '00000000-0000-0000-0000-000000000002']);
@@ -50,7 +59,7 @@ class MessagesControllerTest extends IntegrationTestCase
         parent::tearDown();
     }
 
-    public function testFolder()
+    public function testFolder(): void
     {
         $this->get('/messaging-center/messages/folder');
 
@@ -60,7 +69,7 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertEquals(1, $this->viewVariable('messages')->count());
     }
 
-    public function testFolderInbox()
+    public function testFolderInbox(): void
     {
         $this->get('/messaging-center/messages/folder/inbox');
 
@@ -70,7 +79,7 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertEquals(1, $this->viewVariable('messages')->count());
     }
 
-    public function testFolderArchived()
+    public function testFolderArchived(): void
     {
         $this->get('/messaging-center/messages/folder/archived');
 
@@ -80,7 +89,7 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertEquals(1, $this->viewVariable('messages')->count());
     }
 
-    public function testFolderSent()
+    public function testFolderSent(): void
     {
         $this->get('/messaging-center/messages/folder/sent');
 
@@ -90,7 +99,7 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertTrue($this->viewVariable('messages')->isEmpty());
     }
 
-    public function testFolderTrash()
+    public function testFolderTrash(): void
     {
         $this->get('/messaging-center/messages/folder/trash');
 
@@ -100,7 +109,7 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertEquals(1, $this->viewVariable('messages')->count());
     }
 
-    public function testViewInboxMessage()
+    public function testViewInboxMessage(): void
     {
         $this->get('/messaging-center/messages/view/00000000-0000-0000-0000-000000000001');
 
@@ -109,7 +118,7 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertInstanceOf(Message::class, $this->viewVariable('message'));
     }
 
-    public function testViewSentMessage()
+    public function testViewSentMessage(): void
     {
         $this->session(['Auth.User.id' => '00000000-0000-0000-0000-000000000001']);
 
@@ -120,7 +129,7 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertInstanceOf(Message::class, $this->viewVariable('message'));
     }
 
-    public function testViewDeletedMessage()
+    public function testViewDeletedMessage(): void
     {
         $this->get('/messaging-center/messages/view/00000000-0000-0000-0000-000000000002');
 
@@ -129,7 +138,7 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertInstanceOf(Message::class, $this->viewVariable('message'));
     }
 
-    public function testViewArchivedMessage()
+    public function testViewArchivedMessage(): void
     {
         $this->get('/messaging-center/messages/view/00000000-0000-0000-0000-000000000003');
 
@@ -138,14 +147,14 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertInstanceOf(Message::class, $this->viewVariable('message'));
     }
 
-    public function testViewForbidden()
+    public function testViewForbidden(): void
     {
         $this->get('/messaging-center/messages/view/00000000-0000-0000-0000-000000000004');
 
         $this->assertResponseCode(403);
     }
 
-    public function testCompose()
+    public function testCompose(): void
     {
         $this->get('/messaging-center/messages/compose');
 
@@ -155,7 +164,7 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertTrue($this->viewVariable('message')->isNew());
     }
 
-    public function testComposePost()
+    public function testComposePost(): void
     {
         $expected = 1 + $this->MessagesTable->find('all')->count();
 
@@ -177,16 +186,23 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertEquals($expected, $this->MessagesTable->find('all')->count());
 
         $query = $this->MessagesTable->find()->limit(1)->where(['subject' => $data['subject']]);
+        /**
+         * @var \MessagingCenter\Model\Entity\Message $entity
+         */
         $entity = $query->first();
         $this->assertEquals($data['to_user'], $entity->to_user);
         $this->assertEquals($data['content'], $entity->content);
-        $this->assertEquals($this->_requestSession->read('Auth.User.id'), $entity->from_user);
+        /**
+         * @var \Cake\Http\Session $session
+         */
+        $session = $this->_requestSession;
+        $this->assertEquals($session->read('Auth.User.id'), $entity->from_user);
         $this->assertEquals('new', $entity->status);
         $time = new Time();
         $this->assertEquals($time->i18nFormat(), $entity->date_sent->i18nFormat());
     }
 
-    public function testComposePostNoData()
+    public function testComposePostNoData(): void
     {
         $expected = $this->MessagesTable->find('all')->count();
         $this->post('/messaging-center/messages/compose');
@@ -196,7 +212,7 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertEquals($expected, $this->MessagesTable->find('all')->count());
     }
 
-    public function testComposePostEnforceData()
+    public function testComposePostEnforceData(): void
     {
         $expected = 1 + $this->MessagesTable->find('all')->count();
 
@@ -214,13 +230,16 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertEquals($expected, $this->MessagesTable->find('all')->count());
 
         $query = $this->MessagesTable->find()->limit(1)->where(['subject' => $data['subject']]);
+        /**
+         * @var \MessagingCenter\Model\Entity\Message $entity
+         */
         $entity = $query->first();
         $this->assertNotEquals($data['from_user'], $entity->from_user);
         $this->assertNotEquals($data['status'], $entity->status);
         $this->assertNotEquals($data['date_sent'], $entity->date_sent);
     }
 
-    public function testReply()
+    public function testReply(): void
     {
         $id = '00000000-0000-0000-0000-000000000001';
         $this->get('/messaging-center/messages/reply/' . $id);
@@ -231,7 +250,7 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertFalse($this->viewVariable('message')->isNew());
     }
 
-    public function testReplyPut()
+    public function testReplyPut(): void
     {
         $id = '00000000-0000-0000-0000-000000000001';
         $entity = $this->MessagesTable->get($id);
@@ -255,10 +274,17 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertEquals($expected, $this->MessagesTable->find('all')->count());
 
         $query = $this->MessagesTable->find()->limit(1)->where(['subject' => $data['subject']]);
+        /**
+         * @var \MessagingCenter\Model\Entity\Message $newEntity
+         */
         $newEntity = $query->first();
         $this->assertEquals($entity->get('from_user'), $newEntity->to_user);
         $this->assertEquals($data['content'], $newEntity->content);
-        $this->assertEquals($this->_requestSession->read('Auth.User.id'), $newEntity->from_user);
+        /**
+         * @var \Cake\Http\Session $session
+         */
+        $session = $this->_requestSession;
+        $this->assertEquals($session->read('Auth.User.id'), $newEntity->from_user);
         $this->assertEquals('new', $newEntity->status);
         $time = new Time();
         $this->assertEquals($time->i18nFormat(), $newEntity->date_sent->i18nFormat());
@@ -266,7 +292,7 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertEquals($entity->toArray(), $this->MessagesTable->get($id)->toArray());
     }
 
-    public function testReplyPutSameUser()
+    public function testReplyPutSameUser(): void
     {
         $this->session(['Auth.User.id' => '00000000-0000-0000-0000-000000000001']);
 
@@ -292,7 +318,7 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertEquals($expected, $this->MessagesTable->find('all')->count());
     }
 
-    public function testReplyPutNoData()
+    public function testReplyPutNoData(): void
     {
         $id = '00000000-0000-0000-0000-000000000001';
         $expected = $this->MessagesTable->find('all')->count();
@@ -303,7 +329,7 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertEquals($expected, $this->MessagesTable->find('all')->count());
     }
 
-    public function testReplyPutEnforceData()
+    public function testReplyPutEnforceData(): void
     {
         $id = '00000000-0000-0000-0000-000000000001';
         $expected = 1 + $this->MessagesTable->find('all')->count();
@@ -330,6 +356,9 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertEquals($expected, $this->MessagesTable->find('all')->count());
 
         $query = $this->MessagesTable->find()->limit(1)->where(['subject' => $data['subject']]);
+        /**
+         * @var \MessagingCenter\Model\Entity\Message $entity
+         */
         $entity = $query->first();
         $this->assertNotEquals($data['to_user'], $entity->to_user);
         $this->assertNotEquals($data['from_user'], $entity->from_user);
@@ -337,7 +366,7 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertNotEquals($data['date_sent'], $entity->date_sent);
     }
 
-    public function testDelete()
+    public function testDelete(): void
     {
         $id = '00000000-0000-0000-0000-000000000001';
 
@@ -356,7 +385,7 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertEquals('deleted', $entity->get('status'));
     }
 
-    public function testDeleteAlreadyDeleted()
+    public function testDeleteAlreadyDeleted(): void
     {
         $id = '00000000-0000-0000-0000-000000000002';
 
@@ -376,7 +405,7 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertEquals('deleted', $entity->get('status'));
     }
 
-    public function testDeleteUserSent()
+    public function testDeleteUserSent(): void
     {
         $this->session(['Auth.User.id' => '00000000-0000-0000-0000-000000000001']);
 
@@ -398,7 +427,7 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertEquals('new', $entity->get('status'));
     }
 
-    public function testArchive()
+    public function testArchive(): void
     {
         $id = '00000000-0000-0000-0000-000000000001';
 
@@ -417,7 +446,7 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertEquals('archived', $entity->get('status'));
     }
 
-    public function testArchiveAlreadyArchived()
+    public function testArchiveAlreadyArchived(): void
     {
         $id = '00000000-0000-0000-0000-000000000003';
 
@@ -437,7 +466,7 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertEquals('archived', $entity->get('status'));
     }
 
-    public function testArchiveUserSent()
+    public function testArchiveUserSent(): void
     {
         $this->session(['Auth.User.id' => '00000000-0000-0000-0000-000000000001']);
 
@@ -459,7 +488,7 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertEquals('new', $entity->get('status'));
     }
 
-    public function testRestoreDeleted()
+    public function testRestoreDeleted(): void
     {
         $id = '00000000-0000-0000-0000-000000000002';
 
@@ -478,7 +507,7 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertNotEquals('archived', $entity->get('status'));
     }
 
-    public function testRestoreArchived()
+    public function testRestoreArchived(): void
     {
         $id = '00000000-0000-0000-0000-000000000003';
 
@@ -497,7 +526,7 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertNotEquals('archived', $entity->get('status'));
     }
 
-    public function testRestoreNotArchived()
+    public function testRestoreNotArchived(): void
     {
         $id = '00000000-0000-0000-0000-000000000001';
 
@@ -517,7 +546,7 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertEquals('new', $entity->get('status'));
     }
 
-    public function testRestoreUserSent()
+    public function testRestoreUserSent(): void
     {
         $this->session(['Auth.User.id' => '00000000-0000-0000-0000-000000000001']);
 
@@ -536,7 +565,11 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertRedirect($url);
 
         $entity = $this->MessagesTable->get($id);
-        $this->assertEquals($this->_requestSession->read('Auth.User.id'), $entity->get('from_user'));
+        /**
+         * @var \Cake\Http\Session $session
+         */
+        $session = $this->_requestSession;
+        $this->assertEquals($session->read('Auth.User.id'), $entity->get('from_user'));
         $this->assertEquals('new', $entity->get('status'));
     }
 }

--- a/tests/TestCase/Event/Model/UserListenerTest.php
+++ b/tests/TestCase/Event/Model/UserListenerTest.php
@@ -25,7 +25,7 @@ class UserListenerTest extends TestCase
         $this->Users = TableRegistry::get('CakeDC/Users.Users');
 
         // enable event tracking
-        $this->Users->eventManager()->setEventList(new EventList());
+        $this->Users->getEventManager()->setEventList(new EventList());
 
         EventManager::instance()->on(new UserListener());
     }
@@ -54,7 +54,7 @@ class UserListenerTest extends TestCase
         // trigger event
         $result = $this->Users->save($entity);
 
-        $this->assertEventFired('Model.afterSave', $this->Users->eventManager());
+        $this->assertEventFired('Model.afterSave', $this->Users->getEventManager());
 
         $subject = 'Welcome to Project Name';
         $content = "\nDear foobar<br>\n<br>\n$subject\nBest regards,\nSYSTEM";

--- a/tests/TestCase/Event/Model/UserListenerTest.php
+++ b/tests/TestCase/Event/Model/UserListenerTest.php
@@ -16,13 +16,22 @@ class UserListenerTest extends TestCase
         'plugin.MessagingCenter.messages',
     ];
 
+    /**
+     * @var \CakeDC\Users\Model\Table\UsersTable $Users
+     */
+    protected $Users;
+
     public function setUp()
     {
         parent::setUp();
 
         Configure::write('Users.table', 'CakeDC/Users.Users');
 
-        $this->Users = TableRegistry::get('CakeDC/Users.Users');
+        /**
+         * @var \CakeDC\Users\Model\Table\UsersTable $table
+         */
+        $table = TableRegistry::get('CakeDC/Users.Users');
+        $this->Users = $table;
 
         // enable event tracking
         $this->Users->getEventManager()->setEventList(new EventList());
@@ -37,7 +46,7 @@ class UserListenerTest extends TestCase
         parent::tearDown();
     }
 
-    public function testAfterSave()
+    public function testAfterSave(): void
     {
         $table = TableRegistry::get('MessagingCenter.Messages');
 
@@ -59,13 +68,16 @@ class UserListenerTest extends TestCase
         $subject = 'Welcome to Project Name';
         $content = "\nDear foobar<br>\n<br>\n$subject\nBest regards,\nSYSTEM";
 
+        /**
+         * @var \MessagingCenter\Model\Entity\Message $entity
+         */
         $entity = $table->find()->limit(1)->where(['subject' => $subject])->first();
         $this->assertEquals($content, $entity->get('content'));
 
         $this->assertEquals($expected, $table->find()->count());
     }
 
-    public function testAfterSaveNoWelcomeMessage()
+    public function testAfterSaveNoWelcomeMessage(): void
     {
         Configure::write('MessagingCenter.welcomeMessage.enabled', false);
 

--- a/tests/TestCase/Model/Behavior/NotifyBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/NotifyBehaviorTest.php
@@ -16,8 +16,8 @@ class NotifyBehaviorTest extends TestCase
     {
         parent::setUp();
 
-        $this->Articles = TableRegistry::get('MessagingCenter.Articles', ['table' => 'articles']);
-        $this->Articles->displayField('title');
+        $this->Articles = TableRegistry::get('Articles', ['table' => 'articles']);
+        $this->Articles->setDisplayField('title');
         $this->Articles->belongsTo('Users', [
             'foreignKey' => 'author',
             'className' => 'Users'
@@ -39,7 +39,7 @@ class NotifyBehaviorTest extends TestCase
 
     public function testInitialize()
     {
-        $result = $this->Behavior->config('ignoredFields');
+        $result = $this->Behavior->getConfig('ignoredFields');
         $expected = ['id'];
         $this->assertEquals($expected, $result);
     }
@@ -66,7 +66,7 @@ class NotifyBehaviorTest extends TestCase
 
         $expected = [
             'subject' => 'Article: New Article',
-            'content' => 'Article record <a href="/messaging-center/articles/view/' . $result->id . '">New Article</a> has been assinged to you via \'Author\' field.' . "\n"
+            'content' => 'Article record <a href="/articles/view/' . $result->id . '">New Article</a> has been assinged to you via \'Author\' field.' . "\n"
         ];
 
         $table = TableRegistry::get('MessagingCenter.Messages');
@@ -91,7 +91,7 @@ class NotifyBehaviorTest extends TestCase
 
         $expected = [
             'subject' => 'Article: Modified Article',
-            'content' => 'Article <a href="/messaging-center/articles/view/' . $result->id . '">Modified Article</a> has been modified.' . "\n\n" . '* <strong>Title</strong>: changed from \'First Article\' to \'Modified Article\'.' . "\n" . '* <strong>Body</strong>: changed from \'First Article Body\' to \'Modified Article Body\'.' . "\n"
+            'content' => 'Article <a href="/articles/view/' . $result->id . '">Modified Article</a> has been modified.' . "\n\n" . '* <strong>Title</strong>: changed from \'First Article\' to \'Modified Article\'.' . "\n" . '* <strong>Body</strong>: changed from \'First Article Body\' to \'Modified Article Body\'.' . "\n"
         ];
 
         $table = TableRegistry::get('MessagingCenter.Messages');

--- a/tests/TestCase/Model/Table/MessagesTableTest.php
+++ b/tests/TestCase/Model/Table/MessagesTableTest.php
@@ -38,8 +38,13 @@ class MessagesTableTest extends TestCase
     public function setUp()
     {
         parent::setUp();
-        $config = TableRegistry::exists('Messages') ? [] : ['className' => 'MessagingCenter\Model\Table\MessagesTable'];
-        $this->Messages = TableRegistry::get('Messages', $config);
+
+        $config = TableRegistry::exists('MessagingCenter.Messages') ? [] : ['className' => 'MessagingCenter\Model\Table\MessagesTable'];
+        /**
+         * @var \MessagingCenter\Model\Table\MessagesTable $table
+         */
+        $table = TableRegistry::get('MessagingCenter.Messages', $config);
+        $this->Messages = $table;
     }
 
     /**
@@ -59,7 +64,7 @@ class MessagesTableTest extends TestCase
      *
      * @return void
      */
-    public function testInitialize()
+    public function testInitialize(): void
     {
         $this->assertTrue($this->Messages->hasBehavior('Timestamp'), 'Missing behavior Timestamp.');
         $this->assertInstanceOf('Cake\ORM\Association\BelongsTo', $this->Messages->getAssociation('FromUser'));
@@ -72,7 +77,7 @@ class MessagesTableTest extends TestCase
      *
      * @return void
      */
-    public function testValidationDefault()
+    public function testValidationDefault(): void
     {
         $validator = new Validator();
         $result = $this->Messages->validationDefault($validator);
@@ -85,7 +90,7 @@ class MessagesTableTest extends TestCase
      *
      * @return void
      */
-    public function testBuildRules()
+    public function testBuildRules(): void
     {
         $rules = new RulesChecker();
         $result = $this->Messages->buildRules($rules);
@@ -93,107 +98,128 @@ class MessagesTableTest extends TestCase
         $this->assertInstanceOf(RulesChecker::class, $result);
     }
 
-    public function testGetNewStatus()
+    public function testGetNewStatus(): void
     {
         $this->assertEquals('new', $this->Messages->getNewStatus());
     }
 
-    public function testGetReadStatus()
+    public function testGetReadStatus(): void
     {
         $this->assertEquals('read', $this->Messages->getReadStatus());
     }
 
-    public function testGetDeletedStatus()
+    public function testGetDeletedStatus(): void
     {
         $this->assertEquals('deleted', $this->Messages->getDeletedStatus());
     }
 
-    public function testGetArchivedStatus()
+    public function testGetArchivedStatus(): void
     {
         $this->assertEquals('archived', $this->Messages->getArchivedStatus());
     }
 
-    public function testGetDateSent()
+    public function testGetDateSent(): void
     {
         $time = new Time();
         $this->assertEquals($time->i18nFormat(), $this->Messages->getDateSent()->i18nFormat());
     }
 
-    public function testGetSentFolder()
+    public function testGetSentFolder(): void
     {
         $this->assertEquals('sent', $this->Messages->getSentFolder());
     }
 
-    public function testGetDefaultFolder()
+    public function testGetDefaultFolder(): void
     {
         $this->assertEquals('inbox', $this->Messages->getDefaultFolder());
     }
 
-    public function testGetFolders()
+    public function testGetFolders(): void
     {
         $this->assertEquals(['inbox', 'archived', 'sent', 'trash'], $this->Messages->getFolders());
     }
 
-    public function testFolderExists()
+    public function testFolderExists(): void
     {
         $this->assertTrue($this->Messages->folderExists('inbox'));
     }
 
-    public function testFolderExistsNot()
+    public function testFolderExistsNot(): void
     {
         $this->assertFalse($this->Messages->folderExists('foo'));
     }
 
-    public function testGetFolderByMessageFromUser()
+    public function testGetFolderByMessageFromUser(): void
     {
+        /**
+         * @var \MessagingCenter\Model\Entity\Message $entity
+         */
         $entity = $this->Messages->get('00000000-0000-0000-0000-000000000001');
         $result = $this->Messages->getFolderByMessage($entity, '00000000-0000-0000-0000-000000000001');
 
         $this->assertEquals('sent', $result);
     }
 
-    public function testGetFolderByMessageToUser()
+    public function testGetFolderByMessageToUser(): void
     {
+        /**
+         * @var \MessagingCenter\Model\Entity\Message $entity
+         */
         $entity = $this->Messages->get('00000000-0000-0000-0000-000000000001');
         $result = $this->Messages->getFolderByMessage($entity, '00000000-0000-0000-0000-000000000002');
 
         $this->assertEquals('inbox', $result);
     }
 
-    public function testGetFolderByDeletedMessageFromUser()
+    public function testGetFolderByDeletedMessageFromUser(): void
     {
+        /**
+         * @var \MessagingCenter\Model\Entity\Message $entity
+         */
         $entity = $this->Messages->get('00000000-0000-0000-0000-000000000002');
         $result = $this->Messages->getFolderByMessage($entity, '00000000-0000-0000-0000-000000000001');
 
         $this->assertEquals('sent', $result);
     }
 
-    public function testGetFolderByDeletedMessageToUser()
+    public function testGetFolderByDeletedMessageToUser(): void
     {
+        /**
+         * @var \MessagingCenter\Model\Entity\Message $entity
+         */
         $entity = $this->Messages->get('00000000-0000-0000-0000-000000000002');
         $result = $this->Messages->getFolderByMessage($entity, '00000000-0000-0000-0000-000000000002');
 
         $this->assertEquals('trash', $result);
     }
 
-    public function testGetFolderByArchivedMessageFromUser()
+    public function testGetFolderByArchivedMessageFromUser(): void
     {
+        /**
+         * @var \MessagingCenter\Model\Entity\Message $entity
+         */
         $entity = $this->Messages->get('00000000-0000-0000-0000-000000000003');
         $result = $this->Messages->getFolderByMessage($entity, '00000000-0000-0000-0000-000000000001');
 
         $this->assertEquals('sent', $result);
     }
 
-    public function testGetFolderByArchivedMessageToUser()
+    public function testGetFolderByArchivedMessageToUser(): void
     {
+        /**
+         * @var \MessagingCenter\Model\Entity\Message $entity
+         */
         $entity = $this->Messages->get('00000000-0000-0000-0000-000000000003');
         $result = $this->Messages->getFolderByMessage($entity, '00000000-0000-0000-0000-000000000002');
 
         $this->assertEquals('archived', $result);
     }
 
-    public function testGetFolderByReferer()
+    public function testGetFolderByReferer(): void
     {
+        /**
+         * @var \MessagingCenter\Model\Entity\Message $entity
+         */
         $entity = $this->Messages->get('00000000-0000-0000-0000-000000000001');
         $userId = '00000000-0000-0000-0000-000000000001';
         $referer = '/folder/archived';
@@ -202,7 +228,7 @@ class MessagesTableTest extends TestCase
         $this->assertEquals('archived', $result);
     }
 
-    public function testGetConditionsByFolderDefault()
+    public function testGetConditionsByFolderDefault(): void
     {
         $folder = '';
         $userId = '00000000-0000-0000-0000-000000000001';
@@ -215,7 +241,7 @@ class MessagesTableTest extends TestCase
         $this->assertEquals($expected, $this->Messages->getConditionsByFolder($userId, $folder));
     }
 
-    public function testGetConditionsByFolderInbox()
+    public function testGetConditionsByFolderInbox(): void
     {
         $folder = 'inbox';
         $userId = '00000000-0000-0000-0000-000000000001';
@@ -228,7 +254,7 @@ class MessagesTableTest extends TestCase
         $this->assertEquals($expected, $this->Messages->getConditionsByFolder($userId, $folder));
     }
 
-    public function testGetConditionsByFolderArchived()
+    public function testGetConditionsByFolderArchived(): void
     {
         $folder = 'archived';
         $userId = '00000000-0000-0000-0000-000000000001';
@@ -241,7 +267,7 @@ class MessagesTableTest extends TestCase
         $this->assertEquals($expected, $this->Messages->getConditionsByFolder($userId, $folder));
     }
 
-    public function testGetConditionsByFolderSent()
+    public function testGetConditionsByFolderSent(): void
     {
         $folder = 'sent';
         $userId = '00000000-0000-0000-0000-000000000001';
@@ -253,7 +279,7 @@ class MessagesTableTest extends TestCase
         $this->assertEquals($expected, $this->Messages->getConditionsByFolder($userId, $folder));
     }
 
-    public function testGetConditionsByFolderTrash()
+    public function testGetConditionsByFolderTrash(): void
     {
         $folder = 'trash';
         $userId = '00000000-0000-0000-0000-000000000001';

--- a/tests/TestCase/Model/Table/MessagesTableTest.php
+++ b/tests/TestCase/Model/Table/MessagesTableTest.php
@@ -62,8 +62,8 @@ class MessagesTableTest extends TestCase
     public function testInitialize()
     {
         $this->assertTrue($this->Messages->hasBehavior('Timestamp'), 'Missing behavior Timestamp.');
-        $this->assertInstanceOf('Cake\ORM\Association\BelongsTo', $this->Messages->association('FromUser'));
-        $this->assertInstanceOf('Cake\ORM\Association\BelongsTo', $this->Messages->association('ToUser'));
+        $this->assertInstanceOf('Cake\ORM\Association\BelongsTo', $this->Messages->getAssociation('FromUser'));
+        $this->assertInstanceOf('Cake\ORM\Association\BelongsTo', $this->Messages->getAssociation('ToUser'));
         $this->assertInstanceOf(MessagesTable::class, $this->Messages);
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,37 +1,34 @@
 <?php
-// @codingStandardsIgnoreFile
-
 use Cake\Core\Configure;
 use Cake\Filesystem\Folder;
 
 $pluginName = 'MessagingCenter';
 if (empty($pluginName)) {
-    throw new \Exception("Plugin name is not configured");
+    throw new \RuntimeException("Plugin name is not configured");
 }
 
-$findRoot = function () {
-    $root = dirname(__DIR__);
-    if (is_dir($root . '/vendor/cakephp/cakephp')) {
-        return $root;
-    }
-
-    $root = dirname(dirname(__DIR__));
-    if (is_dir($root . '/vendor/cakephp/cakephp')) {
-        return $root;
-    }
-
-    $root = dirname(dirname(dirname(__DIR__)));
-    if (is_dir($root . '/vendor/cakephp/cakephp')) {
-        return $root;
-    }
-
-    throw new \Exception("Failed to find CakePHP");
+/*
+ * Test suite bootstrap
+ *
+ * This function is used to find the location of CakePHP whether CakePHP
+ * has been installed as a dependency of the plugin, or the plugin is itself
+ * installed as a dependency of an application.
+ */
+$findRoot = function ($root) {
+    do {
+        $lastRoot = $root;
+        $root = dirname($root);
+        if (is_dir($root . '/vendor/cakephp/cakephp')) {
+            return $root;
+        }
+    } while ($root !== $lastRoot);
+    throw new \RuntimeException("Failed to find CakePHP");
 };
 
 if (!defined('DS')) {
     define('DS', DIRECTORY_SEPARATOR);
 }
-define('ROOT', $findRoot());
+define('ROOT', $findRoot(__FILE__));
 define('APP_DIR', 'App');
 define('WEBROOT_DIR', 'webroot');
 define('APP', ROOT . '/tests/App/');
@@ -83,7 +80,7 @@ $cache = [
     ]
 ];
 
-Cake\Cache\Cache::config($cache);
+Cake\Cache\Cache::setConfig($cache);
 Cake\Core\Configure::write('Session', [
     'defaults' => 'php'
 ]);
@@ -93,13 +90,13 @@ if (!getenv('db_dsn')) {
     putenv('db_dsn=sqlite:///:memory:');
 }
 
-Cake\Datasource\ConnectionManager::config('default', [
+Cake\Datasource\ConnectionManager::setConfig('default', [
     'url' => getenv('db_dsn'),
     'quoteIdentifiers' => true,
     'timezone' => 'UTC'
 ]);
 
-Cake\Datasource\ConnectionManager::config('test', [
+Cake\Datasource\ConnectionManager::setConfig('test', [
     'url' => getenv('db_dsn'),
     'quoteIdentifiers' => true,
     'timezone' => 'UTC'
@@ -108,11 +105,8 @@ Cake\Datasource\ConnectionManager::config('test', [
 // Alias AppController to the test App
 class_alias($pluginName . '\Test\App\Controller\AppController', 'App\Controller\AppController');
 // If plugin has routes.php/bootstrap.php then load them, otherwise don't.
-$loadPluginRoutes = file_exists(dirname(__FILE__) . DS . 'config' . DS . 'routes.php');
-$loadPluginBootstrap = file_exists(dirname(__FILE__) . DS . 'config' . DS . 'bootstrap.php');
+$loadPluginRoutes = file_exists(ROOT . DS . 'config' . DS . 'routes.php');
+$loadPluginBootstrap = file_exists(ROOT . DS . 'config' . DS . 'bootstrap.php');
 Cake\Core\Plugin::load($pluginName, ['path' => ROOT . DS, 'autoload' => true, 'routes' => $loadPluginRoutes, 'bootstrap' => $loadPluginBootstrap]);
-
-Cake\Routing\DispatcherFactory::add('Routing');
-Cake\Routing\DispatcherFactory::add('ControllerFactory');
 
 Configure::load('MessagingCenter.messaging_center');

--- a/tests/config/routes.php
+++ b/tests/config/routes.php
@@ -5,10 +5,4 @@ use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Routing\Router;
 
-/**
- * Load all plugin routes.  See the Plugin documentation on
- * how to customize the loading of plugin routes.
- */
-Plugin::routes();
-
 Router::connect('/users/login', ['controller' => 'Users', 'action' => 'login']);

--- a/tests/config/routes.php
+++ b/tests/config/routes.php
@@ -1,8 +1,8 @@
 <?php
 namespace MessagingCenter\Test\App\Config;
 
-use Cake\Core\Configure;
-use Cake\Core\Plugin;
 use Cake\Routing\Router;
+use Cake\Routing\Route\DashedRoute;
 
-Router::connect('/users/login', ['controller' => 'Users', 'action' => 'login']);
+Router::defaultRouteClass(DashedRoute::class);
+Router::connect('/:controller/:action/*');


### PR DESCRIPTION
* Updated to [cakephp-plugin-template v5.2.1](https://github.com/QoboLtd/cakephp-plugin-template/releases/tag/v5.2.1).
* Updated `composer.json`.
* Fixed all of deprecated errors for CakePHP 3.6.
* Fixed all of PHPStan issues.
* Enabled PHPStan on TravisCI