### PR TITLE
Minor improvements on fetching emails

### DIFF
--- a/src/Shell/FetchMailShell.php
+++ b/src/Shell/FetchMailShell.php
@@ -148,9 +148,9 @@ class FetchMailShell extends Shell
                 $message = $remoteMailbox->getMail($messageHeader->uid);
 
                 $this->saveMessage($message, $mailbox);
-                $this->out(sprintf('Message %s saved', $messageHeader->message_id));
+                $this->out(sprintf('Message %s saved', trim($messageHeader->message_id)));
             } catch (InvalidArgumentException | PersistenceFailedException $e) {
-                $this->err(sprintf('Message %s can not be saved. %s', $messageHeader->message_id,
+                $this->err(sprintf('Message %s can not be saved. %s', trim($messageHeader->message_id),
                     $e->getMessage()));
             }
         }

--- a/src/Shell/FetchMailShell.php
+++ b/src/Shell/FetchMailShell.php
@@ -17,6 +17,7 @@ use Cake\Datasource\EntityInterface;
 use Cake\ORM\Exception\PersistenceFailedException;
 use Cake\ORM\Query;
 use Cake\ORM\TableRegistry;
+use DateTime;
 use InvalidArgumentException;
 use MessagingCenter\Enum\IncomingTransportType;
 use MessagingCenter\Enum\MailboxType;
@@ -209,6 +210,7 @@ class FetchMailShell extends Shell
             'subject' => $message->subject,
             'content' => $message->textHtml,
             'status' => 'new',
+            'date_sent' => $this->extractDateTime($message),
             'from_user' => $message->fromAddress,
             'from_name' => $message->fromName,
             'to_user' => $message->toString,
@@ -248,5 +250,27 @@ class FetchMailShell extends Shell
         $result = $query->count();
 
         return ($result > 0);
+    }
+
+    /**
+     * Extracts the DateTime from the provided message
+     *
+     * @param mixed $message Email message object
+     * @return \DateTime
+     */
+    protected function extractDateTime($message): DateTime
+    {
+        if (!empty($message->udate)) {
+            $dateSent = new DateTime($message->udate);
+        } else {
+            $dateSent = DateTime::createFromFormat('Y-m-d H:i:s', $message->date);
+        }
+
+        $errors = DateTime::getLastErrors();
+        if ($dateSent !== false && empty($errors['warning_count'])) {
+            return $dateSent;
+        }
+
+        return new DateTime();
     }
 }

--- a/src/Shell/FetchMailShell.php
+++ b/src/Shell/FetchMailShell.php
@@ -230,9 +230,6 @@ class FetchMailShell extends Shell
      */
     protected function hasMessage(string $messageId, EntityInterface $mailbox): bool
     {
-        $mailboxes = TableRegistry::getTableLocator()->get('MessagingCenter.Mailboxes');
-        Assert::isInstanceOf($mailboxes, MailboxesTable::class);
-
         $table = TableRegistry::getTableLocator()->get('MessagingCenter.Messages');
         Assert::isInstanceOf($table, MessagesTable::class);
 

--- a/src/Shell/FetchMailShell.php
+++ b/src/Shell/FetchMailShell.php
@@ -122,7 +122,6 @@ class FetchMailShell extends Shell
 
                 return;
             }
-
         } catch (InvalidArgumentException | InvalidParameterException | ConnectionException $e) {
             $this->abort($e->getMessage());
 
@@ -152,8 +151,7 @@ class FetchMailShell extends Shell
                 $this->saveMessage($message, $mailbox);
                 $this->out(sprintf('Message %s saved', trim($messageHeader->message_id)));
             } catch (InvalidArgumentException | PersistenceFailedException $e) {
-                $this->err(sprintf('Message %s can not be saved. %s', trim($messageHeader->message_id),
-                    $e->getMessage()));
+                $this->err(sprintf('Message %s can not be saved. %s', trim($messageHeader->message_id), $e->getMessage()));
             }
         }
     }

--- a/src/View/Cell/InboxCell.php
+++ b/src/View/Cell/InboxCell.php
@@ -57,7 +57,7 @@ class InboxCell extends Cell
             try {
                 $mailbox = $mailboxes->getSystemMailbox($user);
                 Assert::isInstanceOf($mailbox, EntityInterface::class);
-            }  catch ( InvalidArgumentException $e ) {
+            } catch (InvalidArgumentException $e) {
                 $this->set('unreadFormat', $format);
                 $this->set('unreadCount', 0);
                 $this->set('maxUnreadCount', static::MAX_UNREAD_COUNT);

--- a/src/View/Cell/InboxCell.php
+++ b/src/View/Cell/InboxCell.php
@@ -15,6 +15,7 @@ use Cake\Datasource\EntityInterface;
 use Cake\ORM\Query;
 use Cake\ORM\TableRegistry;
 use Cake\View\Cell;
+use InvalidArgumentException;
 use MessagingCenter\Model\Table\MailboxesTable;
 use Webmozart\Assert\Assert;
 
@@ -53,8 +54,16 @@ class InboxCell extends Cell
             $mailboxes = TableRegistry::getTableLocator()->get('MessagingCenter.Mailboxes');
             Assert::isInstanceOf($mailboxes, MailboxesTable::class);
 
-            $mailbox = $mailboxes->getSystemMailbox($user);
-            Assert::isInstanceOf($mailbox, EntityInterface::class);
+            try {
+                $mailbox = $mailboxes->getSystemMailbox($user);
+                Assert::isInstanceOf($mailbox, EntityInterface::class);
+            }  catch ( InvalidArgumentException $e ) {
+                $this->set('unreadFormat', $format);
+                $this->set('unreadCount', 0);
+                $this->set('maxUnreadCount', static::MAX_UNREAD_COUNT);
+
+                return;
+            }
         }
 
         $mailboxId = $mailbox->get('id');


### PR DESCRIPTION
This PR introduces minor improvements when fetching emails. In particular:

* Email headers are now being used to check whether the email has been already parsed and created. That is to avoid downloading the message body, if that's not needed.
* Execution is no longer halted if a particular message can not be processed and the next message will be picked up.
* Date is extracted from the email headers and stored in `date_sent` field. Further work may be required for timezone support.
* Message IDs are being trimmed (We have noticed that Office 365 provide Message ID with extra leading spaces)
* Add default values for unread messages when there are not mailboxes defined.