### PR TITLE
Attachments & File Storage (task #11323)

### DIFF
--- a/src/Model/Table/MessagesTable.php
+++ b/src/Model/Table/MessagesTable.php
@@ -74,6 +74,11 @@ class MessagesTable extends Table
             'propertyName' => 'toUser'
         ]);
 
+        $this->hasMany('attachments', [
+            'className' => 'Burzum/FileStorage.FileStorage',
+            'foreignKey' => 'foreign_key',
+        ]);
+
         $this->addBehavior('Timestamp');
     }
 


### PR DESCRIPTION
This PR introduce support for FileStorage plugin and attachments. Attachments are now being fetched and save into the FileStorage table.

Tests will be added in a separated PR where we will move of the Shell methods, into Model classes.