### PR TITLE
Minor fixes (task #12077)

### DIFF
--- a/config/Migrations/20190821100250_AlterMessagesTableSubjectColumn.php
+++ b/config/Migrations/20190821100250_AlterMessagesTableSubjectColumn.php
@@ -1,0 +1,25 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AlterMessagesTableSubjectColumn extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('qobo_messages');
+
+        $table->changeColumn('subject', 'string', [
+            'default' => null,
+            'limit' => 255,
+            'null' => true
+        ]);
+
+        $table->update();
+    }
+}

--- a/config/messaging_center.php
+++ b/config/messaging_center.php
@@ -26,9 +26,21 @@ return [
             'default' => [
                 'mailbox_type' => 'system',
                 'incoming_transport' => 'internal',
-                'incoming_settings' => 'default',
+                'incoming_settings' => [
+                    'username' => '',
+                    'password' => '',
+                    'host' => 'localhost',
+                    'port' => 993,
+                    'protocol' => 'imap'
+                ],
                 'outgoing_transport' => 'internal',
-                'outgoing_settings' => 'default',
+                'outgoing_settings' => [
+                    'username' => '',
+                    'password' => '',
+                    'host' => 'localhost',
+                    'port' => 465,
+                    'protocol' => 'smtp'
+                ],
                 'mailbox_postfix' => '@system',
             ],
             'types' => [

--- a/src/Controller/FoldersController.php
+++ b/src/Controller/FoldersController.php
@@ -1,8 +1,6 @@
 <?php
 namespace MessagingCenter\Controller;
 
-use MessagingCenter\Controller\AppController;
-
 /**
  * Folders Controller
  *

--- a/src/Controller/MailboxesController.php
+++ b/src/Controller/MailboxesController.php
@@ -93,8 +93,8 @@ class MailboxesController extends AppController
              */
             $data = $this->request->getData();
 
-            $data['incoming_settings'] = json_encode($data['IncomingSettings']);
-            $data['outgoing_settings'] = json_encode($data['OutgoingSettings']);
+            $data['incoming_settings'] = $data['IncomingSettings'];
+            $data['outgoing_settings'] = $data['OutgoingSettings'];
 
             $mailbox = $this->Mailboxes->patchEntity($mailbox, $data);
             if ($this->Mailboxes->save($mailbox)) {
@@ -140,8 +140,8 @@ class MailboxesController extends AppController
              */
             $data = $this->request->getData();
 
-            $data['incoming_settings'] = json_encode($data['IncomingSettings']);
-            $data['outgoing_settings'] = json_encode($data['OutgoingSettings']);
+            $data['incoming_settings'] = $data['IncomingSettings'];
+            $data['outgoing_settings'] = $data['OutgoingSettings'];
 
             $mailbox = $this->Mailboxes->patchEntity($mailbox, $data);
             if ($this->Mailboxes->save($mailbox)) {

--- a/src/Controller/MailboxesController.php
+++ b/src/Controller/MailboxesController.php
@@ -71,7 +71,7 @@ class MailboxesController extends AppController
                 'FromUser',
                 'ToUser',
             ],
-            'order' => ['Messages.created' => 'DESC']
+            'order' => ['Messages.date_sent' => 'DESC']
         ];
         $messages = $this->paginate($this->Messages);
 

--- a/src/Event/Model/SendEmailListener.php
+++ b/src/Event/Model/SendEmailListener.php
@@ -48,7 +48,7 @@ class SendEmailListener implements EventListenerInterface
             return;
         }
 
-        $outgoingSettings = json_decode($mailbox->get('outgoing_settings'), true);
+        $outgoingSettings = $mailbox->get('outgoing_settings');
 
         Email::configTransport('custom', [
             'host' => (!empty($outgoingSettings['use_ssl']) ? 'ssl://' : '') . $outgoingSettings['host'],

--- a/src/Event/Model/UserListener.php
+++ b/src/Event/Model/UserListener.php
@@ -96,7 +96,7 @@ class UserListener implements EventListenerInterface
             'projectName' => $projectName,
             'subject' => $subject,
             'adminName' => Configure::readOrFail('MessagingCenter.systemUser.name'),
-            'folder' => $mailboxes->getFolderByName($defaultMailbox, MailboxesTable::FOLDER_INBOX),
+            'folder' => $mailboxes->getFolderByName($defaultMailbox, MailboxesTable::FOLDER_INBOX)->get('id'),
         ];
         $this->Notifier->template('MessagingCenter.welcome');
 

--- a/src/Model/Entity/Mailbox.php
+++ b/src/Model/Entity/Mailbox.php
@@ -3,7 +3,6 @@ namespace MessagingCenter\Model\Entity;
 
 use Cake\Core\Configure;
 use Cake\ORM\Entity;
-use InvalidArgumentException;
 use MessagingCenter\Enum\IncomingTransportType;
 use Webmozart\Assert\Assert;
 
@@ -64,7 +63,7 @@ class Mailbox extends Entity
     protected function _getImapConnection(): string
     {
         if ($this->get('incoming_transport') !== (string)IncomingTransportType::IMAP4()) {
-            throw new InvalidArgumentException();
+            return '';
         }
 
         $connectionString = '';

--- a/src/Model/Entity/Mailbox.php
+++ b/src/Model/Entity/Mailbox.php
@@ -1,9 +1,11 @@
 <?php
 namespace MessagingCenter\Model\Entity;
 
+use Cake\Core\Configure;
 use Cake\ORM\Entity;
 use InvalidArgumentException;
 use MessagingCenter\Enum\IncomingTransportType;
+use Webmozart\Assert\Assert;
 
 /**
  * Mailbox Entity
@@ -67,22 +69,18 @@ class Mailbox extends Entity
 
         $connectionString = '';
 
-        $defaultSettings = [
-            'username' => '',
-            'password' => '',
-            'host' => 'localhost',
-            'port' => null,
-            'protocol' => 'imap',
-        ];
+        $defaultSettings = Configure::readOrFail('MessagingCenter.Mailbox.default.incoming_settings');
+        Assert::keyExists($defaultSettings, 'host');
+        Assert::keyExists($defaultSettings, 'port');
+        Assert::keyExists($defaultSettings, 'protocol');
 
-        $settings = $this->get('incoming_settings');
-        $settings = array_merge($defaultSettings, $settings);
+        $settings = array_merge($defaultSettings, $this->get('incoming_settings'));
 
         // See more details at http://php.net/manual/en/function.imap-open.php
         $connectionString .= '{';
-        $connectionString .= $settings['host'] ?? 'localhost';
-        $connectionString .= ':' . ($settings['port'] ?? 993);
-        $connectionString .= '/' . ($settings['protocol'] ?? 'imap');
+        $connectionString .= $settings['host'];
+        $connectionString .= ':' . $settings['port'];
+        $connectionString .= '/' . $settings['protocol'];
         // TODO: Make this optional
         $connectionString .= '/ssl/novalidate-cert';
         $connectionString .= '}';

--- a/src/Model/MessageFactory.php
+++ b/src/Model/MessageFactory.php
@@ -52,7 +52,7 @@ class MessageFactory
             'to_user' => '',
             'headers' => $headers,
             'message_id' => $incomingMail->messageId,
-            'folder_id' => $mailboxes->getFolderByName($mailbox, MailboxesTable::FOLDER_INBOX),
+            'folder_id' => $mailboxes->getFolderByName($mailbox, MailboxesTable::FOLDER_INBOX)->get('id'),
         ]);
 
         $messageCreated = $messages->saveOrFail($entity);

--- a/src/Model/Table/MailboxesTable.php
+++ b/src/Model/Table/MailboxesTable.php
@@ -12,7 +12,6 @@ use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\Validation\Validator;
 use InvalidArgumentException;
-use MessagingCenter\Enum\MailboxType;
 use MessagingCenter\Model\Entity\Folder;
 use MessagingCenter\Model\Entity\Mailbox;
 use Webmozart\Assert\Assert;

--- a/src/Model/Table/MailboxesTable.php
+++ b/src/Model/Table/MailboxesTable.php
@@ -100,8 +100,7 @@ class MailboxesTable extends Table
             ->notEmpty('incoming_transport');
 
         $validator
-            ->scalar('incoming_settings')
-            ->maxLength('incoming_settings', 4294967295)
+            ->isArray('incoming_settings')
             ->requirePresence('incoming_settings', 'create')
             ->notEmpty('incoming_settings');
 
@@ -112,8 +111,7 @@ class MailboxesTable extends Table
             ->notEmpty('outgoing_transport');
 
         $validator
-            ->scalar('outgoing_settings')
-            ->maxLength('outgoing_settings', 4294967295)
+            ->isArray('outgoing_settings')
             ->requirePresence('outgoing_settings', 'create')
             ->notEmpty('outgoing_settings');
 

--- a/src/Model/Table/MessagesTable.php
+++ b/src/Model/Table/MessagesTable.php
@@ -18,6 +18,7 @@ use Cake\Datasource\EntityInterface;
 use Cake\Datasource\QueryInterface;
 use Cake\Event\Event;
 use Cake\I18n\Time;
+use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\Validation\Validator;
@@ -143,7 +144,21 @@ class MessagesTable extends Table
         $validator
             ->allowEmpty('related_id');
 
+        $validator
+            ->uuid('folder_id')
+            ->notEmpty('folder_id');
+
         return $validator;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function buildRules(RulesChecker $rules) : RulesChecker
+    {
+        $rules->add($rules->existsIn('folder_id', 'Folders'));
+
+        return $rules;
     }
 
     /**

--- a/src/Notifier/MessageNotifier.php
+++ b/src/Notifier/MessageNotifier.php
@@ -13,6 +13,7 @@ namespace MessagingCenter\Notifier;
 
 use Cake\I18n\Time;
 use Cake\ORM\TableRegistry;
+use Webmozart\Assert\Assert;
 
 class MessageNotifier extends Notifier
 {
@@ -118,6 +119,7 @@ class MessageNotifier extends Notifier
      */
     public function folder(string $folder): void
     {
+        Assert::uuid($folder);
         $this->_folder = $folder;
     }
 

--- a/src/Template/Mailboxes/edit.ctp
+++ b/src/Template/Mailboxes/edit.ctp
@@ -11,8 +11,8 @@
  */
 
 
-$mailbox->set('IncomingSettings', json_decode($mailbox->get('incoming_settings'), true));
-$mailbox->set('OutgoingSettings', json_decode($mailbox->get('outgoing_settings'), true));
+$mailbox->set('IncomingSettings', $mailbox->get('incoming_settings'));
+$mailbox->set('OutgoingSettings', $mailbox->get('outgoing_settings'));
 ?>
 <section class="content-header">
     <div class="row">

--- a/tests/App/Application.php
+++ b/tests/App/Application.php
@@ -14,7 +14,6 @@
  */
 namespace MessagingCenter\Test\App;
 
-use Cake\Core\Configure;
 use Cake\Error\Middleware\ErrorHandlerMiddleware;
 use Cake\Http\BaseApplication;
 use Cake\Routing\Middleware\AssetMiddleware;

--- a/tests/TestCase/Controller/FoldersControllerTest.php
+++ b/tests/TestCase/Controller/FoldersControllerTest.php
@@ -2,7 +2,6 @@
 namespace MessagingCenter\Test\TestCase\Controller;
 
 use Cake\TestSuite\IntegrationTestCase;
-use MessagingCenter\Controller\FoldersController;
 
 /**
  * MessagingCenter\Controller\FoldersController Test Case

--- a/tests/TestCase/Controller/MailboxesControllerTest.php
+++ b/tests/TestCase/Controller/MailboxesControllerTest.php
@@ -3,7 +3,6 @@ namespace MessagingCenter\Test\TestCase\Controller;
 
 use Cake\Datasource\EntityInterface;
 use Cake\TestSuite\IntegrationTestCase;
-use MessagingCenter\Controller\MailboxesController;
 
 /**
  * MessagingCenter\Controller\MailboxesController Test Case

--- a/tests/TestCase/Controller/MessagesControllerTest.php
+++ b/tests/TestCase/Controller/MessagesControllerTest.php
@@ -157,7 +157,7 @@ class MessagesControllerTest extends IntegrationTestCase
         $this->assertEquals($session->read('Auth.User.id'), $entity->from_user);
         $this->assertEquals('new', $entity->status);
         $time = new Time();
-        $this->assertEquals($time->i18nFormat(), $entity->date_sent->i18nFormat());
+        $this->assertEquals($time->i18nFormat(), $entity->date_sent->i18nFormat(), '', 1);
     }
 
     public function testComposePostNoData(): void

--- a/tests/TestCase/Controller/MessagesControllerTest.php
+++ b/tests/TestCase/Controller/MessagesControllerTest.php
@@ -5,7 +5,6 @@ use Cake\Event\EventManager;
 use Cake\I18n\Time;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\IntegrationTestCase;
-use MessagingCenter\Controller\MessagesController;
 use MessagingCenter\Event\Model\MailboxListener;
 use MessagingCenter\Event\Model\UserListener;
 use MessagingCenter\Model\Entity\Message;

--- a/tests/TestCase/Event/Model/MailboxListenerTest.php
+++ b/tests/TestCase/Event/Model/MailboxListenerTest.php
@@ -28,25 +28,6 @@ class MailboxListenerTest extends TestCase
         parent::setUp();
 
         Configure::write('Users.table', 'CakeDC/Users.Users');
-        Configure::write('MessagingCenter', [
-            'Mailbox' => [
-                'default' => [
-                    'mailbox_type' => 'system',
-                    'incoming_transport' => 'internal',
-                    'incoming_settings' => 'default',
-                    'outgoing_transport' => 'internal',
-                    'outgoing_settings' => 'default',
-                    'mailbox_postfix' => '@system',
-                ]
-            ],
-            'Folder' => [
-                'defaultType' => 'default',
-            ],
-            'systemUser' => [
-                'name' => 'System',
-                'id' => '00000000-0000-0000-0000-000000000000',
-            ],
-        ]);
         $this->mailboxes = TableRegistry::get('MessagingCenter.Mailboxes');
 
         // enable event tracking

--- a/tests/TestCase/Event/Model/MailboxListenerTest.php
+++ b/tests/TestCase/Event/Model/MailboxListenerTest.php
@@ -54,9 +54,9 @@ class MailboxListenerTest extends TestCase
             'name' => 'mytest@system',
             'type' => 'system',
             'incoming_transport' => 'internal',
-            'incoming_settings' => 'default',
+            'incoming_settings' => Configure::read('MessagingCenter.Mailbox.default.incoming_settings'),
             'outgoing_transport' => 'internal',
-            'outgoing_settings' => 'default',
+            'outgoing_settings' => Configure::read('MessagingCenter.Mailbox.default.outgoing_settings'),
             'active' => 1,
         ];
 

--- a/tests/TestCase/Event/Model/UserListenerTest.php
+++ b/tests/TestCase/Event/Model/UserListenerTest.php
@@ -2,7 +2,6 @@
 namespace MessagingCenter\Test\TestCase\Event\Model;
 
 use Cake\Core\Configure;
-use Cake\Core\Plugin;
 use Cake\Event\EventList;
 use Cake\Event\EventManager;
 use Cake\ORM\TableRegistry;

--- a/tests/TestCase/Model/Behavior/NotifyBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/NotifyBehaviorTest.php
@@ -5,7 +5,6 @@ use Cake\Event\EventManager;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use MessagingCenter\Event\Model\MailboxListener;
-use MessagingCenter\Model\Behavior\NotifyBehavior;
 
 class NotifyBehaviorTest extends TestCase
 {

--- a/tests/TestCase/Model/MessageFactoryTest.php
+++ b/tests/TestCase/Model/MessageFactoryTest.php
@@ -6,8 +6,6 @@ use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use MessagingCenter\Model\Entity\Mailbox;
 use MessagingCenter\Model\MessageFactory;
-use MessagingCenter\Model\Table\MailboxesTable;
-use MessagingCenter\Model\Table\MessagesTable;
 use PhpImap\DataPartInfo;
 use PhpImap\IncomingMail;
 use Webmozart\Assert\Assert;

--- a/tests/TestCase/Model/Table/FoldersTableTest.php
+++ b/tests/TestCase/Model/Table/FoldersTableTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace MessagingCenter\Test\TestCase\Model\Table;
 
-use Cake\Core\Configure;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -40,25 +39,6 @@ class FoldersTableTest extends TestCase
     {
         parent::setUp();
         $config = TableRegistry::getTableLocator()->exists('Folders') ? [] : ['className' => FoldersTable::class];
-        Configure::write('MessagingCenter', [
-            'Mailbox' => [
-                'default' => [
-                    'mailbox_type' => 'system',
-                    'incoming_transport' => 'internal',
-                    'incoming_settings' => 'default',
-                    'outgoing_transport' => 'internal',
-                    'outgoing_settings' => 'default',
-                    'mailbox_postfix' => '@system',
-                ]
-            ],
-            'Folder' => [
-                'defaultType' => 'default',
-            ],
-            'systemUser' => [
-                'name' => 'System',
-                'id' => '00000000-0000-0000-0000-000000000000',
-            ],
-        ]);
         /**
          * @var \MessagingCenter\Model\Table\FoldersTable $table
          */

--- a/tests/TestCase/Model/Table/MailboxesTableTest.php
+++ b/tests/TestCase/Model/Table/MailboxesTableTest.php
@@ -178,8 +178,7 @@ class MailboxesTableTest extends TestCase
     public function testSystemConnectionString(): void
     {
         $mailbox = $this->Mailboxes->get('00000000-0000-0000-0000-000000000001');
-        $this->expectException(\InvalidArgumentException::class);
-        $mailbox->get('imap_connection');
+        $this->assertSame('', $mailbox->get('imap_connection'));
     }
 
     public function testEmailConnectionString(): void

--- a/tests/TestCase/Model/Table/MailboxesTableTest.php
+++ b/tests/TestCase/Model/Table/MailboxesTableTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace MessagingCenter\Test\TestCase\Model\Table;
 
-use Cake\Core\Configure;
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\TableRegistry;
@@ -50,26 +49,6 @@ class MailboxesTableTest extends TestCase
          */
         $table = TableRegistry::getTableLocator()->get('Mailboxes', $config);
         $this->Mailboxes = $table;
-
-        Configure::write('MessagingCenter', [
-            'Mailbox' => [
-                'default' => [
-                    'mailbox_type' => 'system',
-                    'incoming_transport' => 'internal',
-                    'incoming_settings' => 'default',
-                    'outgoing_transport' => 'internal',
-                    'outgoing_settings' => 'default',
-                    'mailbox_postfix' => '@system',
-                ]
-            ],
-            'Folder' => [
-                'defaultType' => 'default',
-            ],
-            'systemUser' => [
-                'name' => 'System',
-                'id' => '00000000-0000-0000-0000-000000000000',
-            ],
-        ]);
     }
 
     /**

--- a/tests/TestCase/Model/Table/MessagesTableTest.php
+++ b/tests/TestCase/Model/Table/MessagesTableTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace MessagingCenter\Test\TestCase\Model\Table;
 
-use Cake\Core\Configure;
 use Cake\I18n\Time;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\TableRegistry;
@@ -49,26 +48,6 @@ class MessagesTableTest extends TestCase
          */
         $table = TableRegistry::get('MessagingCenter.Messages', $config);
         $this->Messages = $table;
-
-        Configure::write('MessagingCenter', [
-            'Mailbox' => [
-                'default' => [
-                    'mailbox_type' => 'system',
-                    'incoming_transport' => 'internal',
-                    'incoming_settings' => 'default',
-                    'outgoing_transport' => 'internal',
-                    'outgoing_settings' => 'default',
-                    'mailbox_postfix' => '@system',
-                ]
-            ],
-            'Folder' => [
-                'defaultType' => 'default',
-            ],
-            'systemUser' => [
-                'name' => 'System',
-                'id' => '00000000-0000-0000-0000-000000000000',
-            ],
-        ]);
     }
 
     /**


### PR DESCRIPTION
- Adjusted mailbox default settings
- Removed JSON encode/decode leftovers
- Removed unused imports
- Set subject column as nullable
- Applied stricter `folder_id` validations
- Fixed cases where `folder_id` was not set correctly
- Sort mailbox messages by the date they were sent