### PR TITLE
Load from_user field (task #12642)

### DIFF
--- a/src/Model/Entity/Message.php
+++ b/src/Model/Entity/Message.php
@@ -61,7 +61,7 @@ class Message extends Entity
      */
     protected function getUser(string $field) : string
     {
-        $user = $this->has($field . 'User') ? $this->get($field . 'User') : $this->get($field . 'user');
+        $user = $this->has($field . 'User') ? $this->get($field . 'User') : $this->get($field . '_user');
         $systemUser = Configure::readOrFail('MessagingCenter.systemUser');
 
         if ($user instanceof Entity) {
@@ -97,7 +97,7 @@ class Message extends Entity
      */
     protected function getEmailAddresses(string $field) : array
     {
-        $user = $this->has($field . 'User') ? $this->get($field . 'User') : $this->get($field . 'user');
+        $user = $this->has($field . 'User') ? $this->get($field . 'User') : $this->get($field . '_user');
         $systemUser = Configure::readOrFail('MessagingCenter.systemUser');
 
         if ($user instanceof Entity) {

--- a/src/Model/Table/MailboxesTable.php
+++ b/src/Model/Table/MailboxesTable.php
@@ -293,7 +293,7 @@ class MailboxesTable extends Table
                 'user_id' => $user['id']
             ]);
         $mailbox = $query->first();
-        Assert::isInstanceOf($mailbox, EntityInterface::class, __('User ' . $user['username'] . ' does not have system mailbox!'));
+        Assert::isInstanceOf($mailbox, EntityInterface::class, (string)__('User ' . $user['username'] . ' does not have system mailbox!'));
 
         return $mailbox;
     }

--- a/tests/TestCase/Model/Behavior/NotifyBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/NotifyBehaviorTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace MessagingCenter\Test\TestCase\Model\Behavior;
 
+use Cake\Core\Configure;
 use Cake\Event\EventManager;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
@@ -90,7 +91,9 @@ class NotifyBehaviorTest extends TestCase
 
         $expected = [
             'subject' => 'Article: New Article',
-            'content' => 'Article record <a href="/articles/view/' . $result->id . '">New Article</a> has been assinged to you via \'Author\' field.' . "\n"
+            'content' => 'Article record <a href="/articles/view/' . $result->id . '">New Article</a> has been assinged to you via \'Author\' field.' . "\n",
+            'from_user' => Configure::readOrFail('MessagingCenter.systemUser.id'),
+            'sender' => Configure::readOrFail('MessagingCenter.systemUser.name'),
         ];
 
         $table = TableRegistry::get('MessagingCenter.Messages');
@@ -101,6 +104,8 @@ class NotifyBehaviorTest extends TestCase
 
         $this->assertEquals($expected['subject'], $entity->get('subject'));
         $this->assertEquals($expected['content'], $entity->get('content'));
+        $this->assertEquals($expected['from_user'], $entity->get('from_user'));
+        $this->assertEquals($expected['sender'], $entity->get('sender'));
     }
 
     public function testAfterSaveModified(): void


### PR DESCRIPTION
There was a typo (missing _) causing empty sender names for Notications and other System Messages.