### PR TITLE
Removing unnecessary CakeDC table init

### DIFF
--- a/src/Model/Behavior/NotifyBehavior.php
+++ b/src/Model/Behavior/NotifyBehavior.php
@@ -245,8 +245,7 @@ class NotifyBehavior extends Behavior
      */
     protected function _notifyUser(string $field, EntityInterface $entity, Table $table, array $modifiedFields): void
     {
-        $usersTable = TableRegistry::getTableLocator()->get('CakeDC/Users.Users');
-        $user = $usersTable->get($entity->get($field));
+        $user = $this->_usersTable->get($entity->get($field));
 
         $mailboxes = TableRegistry::getTableLocator()->get('MessagingCenter.Mailboxes');
         Assert::isInstanceOf($mailboxes, MailboxesTable::class);


### PR DESCRIPTION
In the `initialize()` method we set protected variable `_usersTable`, thus no need to initialize directly `CakeDC/Users.Users` table instance.

Furthermore, we can always reuse `$this->getUsersTable()` method that will return correct table from the app/plugin level, based on the setup of the `cakedc/users` plugin