### PR TITLE
Use nl2br method to display the message content (Task #13391)

### DIFF
--- a/src/Template/Messages/view.ctp
+++ b/src/Template/Messages/view.ctp
@@ -112,7 +112,7 @@ $restoreBtn = $this->Form->postLink(
                         </div>
                     </div>
                     <div class="mailbox-read-message">
-                        <?= $message->get('content') ?>
+                        <?= nl2br($message->get('content')) ?>
                     </div>
                 </div>
                 <div class="box-footer">


### PR DESCRIPTION
This PR fixes uses the nl2br method to display the message content as now it display it in one line