### PR TITLE
Message content issue with textPlain and textHtml (Task #13528)

### DIFF
--- a/src/Model/MessageFactory.php
+++ b/src/Model/MessageFactory.php
@@ -31,7 +31,7 @@ class MessageFactory
         $messages = TableRegistry::getTableLocator()->get('MessagingCenter.Messages');
         Assert::isInstanceOf($messages, MessagesTable::class);
 
-        $content = $incomingMail->textPlain ?? $incomingMail->textHtml;
+        $content = !empty($incomingMail->textPlain) ? $incomingMail->textPlain : $incomingMail->textHtml;
 
         /**
          * Retrieve initialStatus for local saved email from configuration.


### PR DESCRIPTION
This PR fixes an issue with the message content that when the textPlain is empty the content is not read from textHtml