### PR TITLE
Set the optional columns as nullable (task #14116)

### DIFF
--- a/config/Migrations/20191113172603_AlterMessagesTable.php
+++ b/config/Migrations/20191113172603_AlterMessagesTable.php
@@ -1,0 +1,24 @@
+<?php
+use Migrations\AbstractMigration;
+use Phinx\Db\Adapter\MysqlAdapter;
+
+class AlterMessagesTable extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $this->table('qobo_messages')
+            ->changeColumn('folder_id', 'uuid', ['default' => null, 'null' => true])
+            ->changeColumn('mime_type', 'string', ['default' => null, 'null' => true, 'limit' => 255])
+            ->changeColumn('preview_content', 'text', ['default' => null, 'null' => true, 'limit' => MysqlAdapter::TEXT_LONG])
+            ->changeColumn('raw_content', 'text', ['default' => null, 'null' => true, 'limit' => MysqlAdapter::TEXT_LONG])
+            ->update();
+    }
+
+}

--- a/tests/Fixture/MessagesFixture.php
+++ b/tests/Fixture/MessagesFixture.php
@@ -2,6 +2,7 @@
 namespace MessagingCenter\Test\Fixture;
 
 use Cake\TestSuite\Fixture\TestFixture;
+use Phinx\Db\Adapter\MysqlAdapter;
 
 /**
  * MessagesFixture
@@ -19,10 +20,10 @@ class MessagesFixture extends TestFixture
     // @codingStandardsIgnoreStart
     public $fields = [
         'id' => ['type' => 'uuid', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
-        'from_user' => ['type' => 'uuid', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
-        'to_user' => ['type' => 'uuid', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
-        'subject' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
-        'content' => ['type' => 'text', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+        'from_user' => ['type' => 'string', 'length' => 100, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+        'to_user' => ['type' => 'string', 'length' => 100, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+        'subject' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+        'content' => ['type' => 'text', 'length' => MysqlAdapter::TEXT_LONG, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
         'content_text' => ['type' => 'text', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
         'date_sent' => ['type' => 'datetime', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
         'status' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
@@ -31,14 +32,18 @@ class MessagesFixture extends TestFixture
         'created' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
         'modified' => ['type' => 'datetime', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
         'folder_id' => ['type' => 'uuid', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
-        'headers' => ['type' => 'text', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
+        'mime_type' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+        'raw_content' => ['type' => 'text', 'length' => MysqlAdapter::TEXT_LONG, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
+        'preview_content' => ['type' => 'text', 'length' => MysqlAdapter::TEXT_LONG, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
         'message_id' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+        'from_name' => ['type' => 'string', 'length' => 100, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+        'headers' => ['type' => 'text', 'length' => MysqlAdapter::TEXT_LONG, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
         '_constraints' => [
             'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
         ],
         '_options' => [
             'engine' => 'InnoDB',
-            'collation' => 'utf8_general_ci'
+            'collation' => 'utf8mb4_general_ci'
         ],
     ];
     // @codingStandardsIgnoreEnd


### PR DESCRIPTION
The following qobo_messsages table columns are now set as nullable:
- folder_id
- mime_type
- preview_content
- raw_content