### PR TITLE
Support for CakePHP v3.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,15 +21,9 @@
         "sort-packages": true,
         "optimize-autoloader": true
     },
-	"repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/QoboLtd/cakephp-utils.git"
-        }
-    ],
     "require": {
         "php-imap/php-imap": "~3.0.0",
-        "qobo/cakephp-utils": "dev-cakephp-v38"
+        "qobo/cakephp-utils": "^13.0"
     },
     "require-dev": {
         "qobo/cakephp-composer-dev": "^v1.0"

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,12 @@
 	"repositories": [
         {
             "type": "git",
-            "url": "https://github.com/QoboLtd/cakephp-file-storage.git"
+            "url": "https://github.com/QoboLtd/cakephp-utils.git"
         }
     ],
     "require": {
-        "php-imap/php-imap": "^3.0",
-        "qobo/cakephp-utils": "^13.0"
+        "php-imap/php-imap": "~3.0.0",
+        "qobo/cakephp-utils": "dev-cakephp-v38"
     },
     "require-dev": {
         "qobo/cakephp-composer-dev": "^v1.0"

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,5 @@
         "test": "Runs phpcs and phpunit without coverage",
         "test-coverage": "Runs phpcs and phpunit with coverage enabled"
     },
-    "prefer-stable": true,
-    "minimum-stability": "dev"
+    "prefer-stable": true
 }

--- a/src/Controller/MessagesController.php
+++ b/src/Controller/MessagesController.php
@@ -12,11 +12,8 @@
 namespace MessagingCenter\Controller;
 
 use Cake\Datasource\EntityInterface;
-use Cake\Event\Event;
-use Cake\Event\EventManager;
 use Cake\ORM\TableRegistry;
 use MessagingCenter\Enum\MailboxType;
-use MessagingCenter\Event\EventName;
 use MessagingCenter\Model\Entity\Folder;
 use MessagingCenter\Model\Entity\Mailbox;
 use MessagingCenter\Model\Entity\Message;

--- a/src/Event/Model/SendEmailListener.php
+++ b/src/Event/Model/SendEmailListener.php
@@ -16,6 +16,7 @@ use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
 use Cake\Event\EventListenerInterface;
 use Cake\Mailer\Email;
+use Cake\Mailer\TransportFactory;
 use Cake\Utility\Inflector;
 use MessagingCenter\Event\EventName;
 use Webmozart\Assert\Assert;
@@ -50,7 +51,7 @@ class SendEmailListener implements EventListenerInterface
 
         $outgoingSettings = $mailbox->get('outgoing_settings');
 
-        Email::configTransport('custom', [
+        TransportFactory::setConfig('custom', [
             'host' => (!empty($outgoingSettings['use_ssl']) ? 'ssl://' : '') . $outgoingSettings['host'],
             'port' => $outgoingSettings['port'],
             'username' => $outgoingSettings['username'],
@@ -65,9 +66,9 @@ class SendEmailListener implements EventListenerInterface
         Assert::isInstanceOf($email, Email::class);
 
         $email->setTransport('custom');
-        $email->from($outgoingSettings['username']);
-        $email->to($data['to_user']);
-        $email->subject($data['subject']);
+        $email->setFrom($outgoingSettings['username']);
+        $email->setTo($data['to_user']);
+        $email->setSubject($data['subject']);
 
         $result = $email->send($data['content']);
     }

--- a/src/Event/Model/UserListener.php
+++ b/src/Event/Model/UserListener.php
@@ -102,7 +102,7 @@ class UserListener implements EventListenerInterface
 
         // broadcast event for modifying message data before passing them to the Notifier
         $event = new Event((string)EventName::NOTIFY_BEFORE_RENDER(), $this, [
-            'table' => TableRegistry::get('Messages'),
+            'table' => TableRegistry::getTableLocator()->get('Messages'),
             'entity' => $entity,
             'data' => $data,
         ]);

--- a/src/Model/Behavior/NotifyBehavior.php
+++ b/src/Model/Behavior/NotifyBehavior.php
@@ -88,7 +88,7 @@ class NotifyBehavior extends Behavior
 
         $this->_fromUser = Configure::readOrFail('MessagingCenter.systemUser.id');
         // get users table
-        $this->_usersTable = TableRegistry::get('Users');
+        $this->_usersTable = TableRegistry::getTableLocator()->get('Users');
 
         $this->Notifier = new MessageNotifier();
     }
@@ -150,9 +150,9 @@ class NotifyBehavior extends Behavior
     protected function _getModifiedFields(EntityInterface $entity): array
     {
         if ($entity->isNew()) {
-            $fields = $entity->extractOriginal($entity->visibleProperties());
+            $fields = $entity->extractOriginal($entity->getVisible());
         } else {
-            $fields = $entity->extractOriginalChanged($entity->visibleProperties());
+            $fields = $entity->extractOriginalChanged($entity->getVisible());
         }
 
         $diff = array_diff(array_keys($fields), $this->_ignoredModifyFields);
@@ -186,7 +186,7 @@ class NotifyBehavior extends Behavior
     {
         $result = [];
         foreach ($table->associations() as $association) {
-            if ($association->className() !== $this->_usersTable->getAlias()) {
+            if ($association->getClassName() !== $this->_usersTable->getAlias()) {
                 continue;
             }
 

--- a/src/Model/Table/FoldersTable.php
+++ b/src/Model/Table/FoldersTable.php
@@ -74,24 +74,24 @@ class FoldersTable extends Table
     {
         $validator
             ->uuid('id')
-            ->allowEmpty('id', 'create');
+            ->allowEmptyString('id', null, 'create');
 
         $validator
             ->scalar('name')
             ->maxLength('name', 255)
             ->requirePresence('name', 'create')
-            ->notEmpty('name');
+            ->notEmptyString('name');
 
         $validator
             ->scalar('type')
             ->maxLength('type', 255)
             ->requirePresence('type', 'create')
-            ->notEmpty('type');
+            ->notEmptyString('type');
 
         $validator
             ->uuid('mailbox_id')
             ->requirePresence('mailbox_id', 'create')
-            ->notEmpty('mailbox_id');
+            ->notEmptyString('mailbox_id');
 
         return $validator;
     }

--- a/src/Model/Table/MailboxesTable.php
+++ b/src/Model/Table/MailboxesTable.php
@@ -78,46 +78,45 @@ class MailboxesTable extends Table
     {
         $validator
             ->uuid('id')
-            ->allowEmpty('id', 'create');
+            ->allowEmptyString('id', null, 'create');
 
         $validator
             ->scalar('name')
             ->maxLength('name', 255)
             ->requirePresence('name', 'create')
-            ->notEmpty('name');
+            ->notEmptyString('name');
 
         $validator
             ->scalar('type')
             ->maxLength('type', 255)
             ->requirePresence('type', 'create')
-            ->notEmpty('type');
+            ->notEmptyString('type');
 
         $validator
             ->scalar('incoming_transport')
             ->maxLength('incoming_transport', 255)
             ->requirePresence('incoming_transport', 'create')
-            ->notEmpty('incoming_transport');
+            ->notEmptyString('incoming_transport');
 
         $validator
             ->isArray('incoming_settings')
             ->requirePresence('incoming_settings', 'create')
-            ->notEmpty('incoming_settings');
+            ->notEmptyArray('incoming_settings');
 
         $validator
             ->scalar('outgoing_transport')
             ->maxLength('outgoing_transport', 255)
             ->requirePresence('outgoing_transport', 'create')
-            ->notEmpty('outgoing_transport');
+            ->notEmptyString('outgoing_transport');
 
         $validator
             ->isArray('outgoing_settings')
             ->requirePresence('outgoing_settings', 'create')
-            ->notEmpty('outgoing_settings');
+            ->notEmptyArray('outgoing_settings');
 
         $validator
             ->boolean('active')
-            ->requirePresence('active', 'create')
-            ->notEmpty('active');
+            ->requirePresence('active', 'create');
 
         return $validator;
     }

--- a/src/Model/Table/MessagesTable.php
+++ b/src/Model/Table/MessagesTable.php
@@ -111,44 +111,44 @@ class MessagesTable extends Table
     {
         $validator
             ->uuid('id')
-            ->allowEmpty('id', 'create');
+            ->allowEmptyString('id', null, 'create');
 
         $validator
             ->requirePresence('from_user', 'create')
-            ->notEmpty('from_user', null, function ($context) {
+            ->notEmptyString('from_user', null, function ($context) {
                 return !empty($context['data']['type']) && $context['data']['type'] === 'system';
             });
         $validator
             ->requirePresence('to_user', 'create')
-            ->notEmpty('to_user', null, function ($context) {
+            ->notEmptyString('to_user', null, function ($context) {
                 return !empty($context['data']['type']) && $context['data']['type'] === 'system';
             });
 
         $validator
             ->requirePresence('subject', 'create')
-            ->allowEmpty('subject');
+            ->allowEmptyString('subject');
 
         $validator
             ->requirePresence('content', 'create')
-            ->notEmpty('content');
+            ->notEmptyString('content');
 
         $validator
             ->dateTime('date_sent')
-            ->allowEmpty('date_sent');
+            ->allowEmptyDateTime('date_sent');
 
         $validator
             ->requirePresence('status', 'create')
-            ->notEmpty('status');
+            ->notEmptyString('status');
 
         $validator
-            ->allowEmpty('related_model');
+            ->allowEmptyString('related_model');
 
         $validator
-            ->allowEmpty('related_id');
+            ->allowEmptyString('related_id');
 
         $validator
             ->uuid('folder_id')
-            ->notEmpty('folder_id');
+            ->notEmptyString('folder_id');
 
         return $validator;
     }

--- a/src/Notifier/MessageNotifier.php
+++ b/src/Notifier/MessageNotifier.php
@@ -88,7 +88,7 @@ class MessageNotifier extends Notifier
         /**
          * @var \MessagingCenter\Model\Table\MessagesTable $table
          */
-        $table = TableRegistry::get('MessagingCenter.Messages');
+        $table = TableRegistry::getTableLocator()->get('MessagingCenter.Messages');
         $this->_table = $table;
 
         // set properties

--- a/src/Notifier/Notifier.php
+++ b/src/Notifier/Notifier.php
@@ -129,7 +129,6 @@ class Notifier implements NotifierInterface
             $View->setPlugin($plugin);
         }
 
-        $View->hasRendered = false;
         $View->setTemplatePath('Notifier');
         $View->setLayoutPath('Notifier');
 

--- a/src/Notifier/Notifier.php
+++ b/src/Notifier/Notifier.php
@@ -126,7 +126,7 @@ class Notifier implements NotifierInterface
 
         list($plugin) = pluginSplit($View->getTemplate());
         if ($plugin) {
-            $View->plugin = $plugin;
+            $View->setPlugin($plugin);
         }
 
         $View->hasRendered = false;

--- a/tests/TestCase/Controller/FoldersControllerTest.php
+++ b/tests/TestCase/Controller/FoldersControllerTest.php
@@ -14,9 +14,9 @@ class FoldersControllerTest extends IntegrationTestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.messaging_center.folders',
-        'plugin.messaging_center.messages',
-        'plugin.messaging_center.mailboxes',
+        'plugin.MessagingCenter.Folders',
+        'plugin.MessagingCenter.Messages',
+        'plugin.MessagingCenter.Mailboxes',
     ];
 
     public function setUp(): void

--- a/tests/TestCase/Controller/MailboxesControllerTest.php
+++ b/tests/TestCase/Controller/MailboxesControllerTest.php
@@ -15,10 +15,10 @@ class MailboxesControllerTest extends IntegrationTestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.CakeDC/Users.users',
-        'plugin.messaging_center.mailboxes',
-        'plugin.messaging_center.folders',
-        'plugin.messaging_center.messages',
+        'plugin.CakeDC/Users.Users',
+        'plugin.MessagingCenter.Mailboxes',
+        'plugin.MessagingCenter.Folders',
+        'plugin.MessagingCenter.Messages',
     ];
 
     public function setUp(): void

--- a/tests/TestCase/Controller/MessagesControllerTest.php
+++ b/tests/TestCase/Controller/MessagesControllerTest.php
@@ -21,10 +21,10 @@ class MessagesControllerTest extends IntegrationTestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.CakeDC/Users.users',
-        'plugin.messaging_center.messages',
-        'plugin.messaging_center.folders',
-        'plugin.messaging_center.mailboxes',
+        'plugin.CakeDC/Users.Users',
+        'plugin.MessagingCenter.Messages',
+        'plugin.MessagingCenter.Folders',
+        'plugin.MessagingCenter.Mailboxes',
         'plugin.Burzum/FileStorage.FileStorage',
     ];
 

--- a/tests/TestCase/Event/Model/MailboxListenerTest.php
+++ b/tests/TestCase/Event/Model/MailboxListenerTest.php
@@ -12,10 +12,10 @@ use MessagingCenter\Event\Model\MailboxListener;
 class MailboxListenerTest extends TestCase
 {
     public $fixtures = [
-        'plugin.CakeDC/Users.users',
-        'plugin.MessagingCenter.mailboxes',
-        'plugin.MessagingCenter.folders',
-        'plugin.MessagingCenter.messages',
+        'plugin.CakeDC/Users.Users',
+        'plugin.MessagingCenter.Mailboxes',
+        'plugin.MessagingCenter.Folders',
+        'plugin.MessagingCenter.Messages',
     ];
 
     /**

--- a/tests/TestCase/Event/Model/UserListenerTest.php
+++ b/tests/TestCase/Event/Model/UserListenerTest.php
@@ -12,10 +12,10 @@ use MessagingCenter\Event\Model\UserListener;
 class UserListenerTest extends TestCase
 {
     public $fixtures = [
-        'plugin.CakeDC/Users.users',
-        'plugin.MessagingCenter.folders',
-        'plugin.MessagingCenter.mailboxes',
-        'plugin.MessagingCenter.messages',
+        'plugin.CakeDC/Users.Users',
+        'plugin.MessagingCenter.Folders',
+        'plugin.MessagingCenter.Mailboxes',
+        'plugin.MessagingCenter.Messages',
     ];
 
     /**

--- a/tests/TestCase/Model/Behavior/NotifyBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/NotifyBehaviorTest.php
@@ -11,8 +11,8 @@ use MessagingCenter\Event\Model\MailboxListener;
 class NotifyBehaviorTest extends TestCase
 {
     public $fixtures = [
-        'plugin.MessagingCenter.articles',
-        'plugin.CakeDC/Users.users',
+        'plugin.MessagingCenter.Articles',
+        'plugin.CakeDC/Users.Users',
     ];
 
     /**

--- a/tests/TestCase/Model/MessageFactoryTest.php
+++ b/tests/TestCase/Model/MessageFactoryTest.php
@@ -13,10 +13,10 @@ use Webmozart\Assert\Assert;
 class MessageFactoryTest extends TestCase
 {
     public $fixtures = [
-        'plugin.CakeDC/Users.users',
-        'plugin.messaging_center.messages',
-        'plugin.messaging_center.folders',
-        'plugin.messaging_center.mailboxes',
+        'plugin.CakeDC/Users.Users',
+        'plugin.MessagingCenter.Messages',
+        'plugin.MessagingCenter.Folders',
+        'plugin.MessagingCenter.Mailboxes',
     ];
 
     public function testCreateFromIncomingMail(): void

--- a/tests/TestCase/Model/Table/FoldersTableTest.php
+++ b/tests/TestCase/Model/Table/FoldersTableTest.php
@@ -26,8 +26,8 @@ class FoldersTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.messaging_center.mailboxes',
-        'plugin.messaging_center.folders',
+        'plugin.MessagingCenter.Mailboxes',
+        'plugin.MessagingCenter.Folders',
     ];
 
     /**

--- a/tests/TestCase/Model/Table/MailboxesTableTest.php
+++ b/tests/TestCase/Model/Table/MailboxesTableTest.php
@@ -27,10 +27,10 @@ class MailboxesTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.CakeDC/Users.users',
-        'plugin.messaging_center.mailboxes',
-        'plugin.messaging_center.folders',
-        'plugin.messaging_center.messages',
+        'plugin.CakeDC/Users.Users',
+        'plugin.MessagingCenter.Mailboxes',
+        'plugin.MessagingCenter.Folders',
+        'plugin.MessagingCenter.Messages',
     ];
 
     /**

--- a/tests/TestCase/Model/Table/MessagesTableTest.php
+++ b/tests/TestCase/Model/Table/MessagesTableTest.php
@@ -27,10 +27,10 @@ class MessagesTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.CakeDC/Users.users',
-        'plugin.messaging_center.mailboxes',
-        'plugin.messaging_center.folders',
-        'plugin.messaging_center.messages',
+        'plugin.CakeDC/Users.Users',
+        'plugin.MessagingCenter.Mailboxes',
+        'plugin.MessagingCenter.Folders',
+        'plugin.MessagingCenter.Messages',
     ];
 
     /**


### PR DESCRIPTION
This PR defines v3.8 as the minimum CakePHP version acceptable and fixes most of the deprecation warnings.