### PR TITLE
Fix migrations for CakePHP v3.8

### DIFF
--- a/config/Migrations/20180327085709_RenameMessages.php
+++ b/config/Migrations/20180327085709_RenameMessages.php
@@ -13,6 +13,7 @@ class RenameMessages extends AbstractMigration
     public function change()
     {
         $this->table('messages')
-            ->rename('qobo_messages');
+            ->rename('qobo_messages')
+            ->save();
     }
 }


### PR DESCRIPTION
We adjust the migrations so that work with CakePHP v3.8

